### PR TITLE
docs: Add JSDoc documentation in src/plainer.ts

### DIFF
--- a/src/plainer.ts
+++ b/src/plainer.ts
@@ -27,6 +27,13 @@ export type MinimisedTree<T> = Tree<T> | Record<string, Tree<T>> | undefined;
 
 const enableLegacyPaths = (version: number) => version < 1;
 
+/**
+ * Recursively walks a minimised annotation tree, invoking a callback for each node value along with its resolved path.
+ * @param tree - The minimised tree structure to traverse
+ * @param walker - Callback invoked with each node's value and its resolved path segments
+ * @param version - Serialization version, used to determine legacy path parsing behavior
+ * @param origin - Accumulated path segments from parent nodes
+ */
 function traverse<T>(
   tree: MinimisedTree<T>,
   walker: (v: T, path: string[]) => void,
@@ -61,6 +68,14 @@ function traverse<T>(
   walker(nodeValue, origin);
 }
 
+/**
+ * Restores transformed values in a plain object by traversing type annotations and applying the reverse transformation for each annotated path.
+ * @param plain - The plain serialized object to restore values into
+ * @param annotations - Tree of type annotations indicating which values need un-transformation
+ * @param version - Serialization version for path parsing compatibility
+ * @param superJson - The SuperJSON instance providing registered custom transformers
+ * @returns The object with all annotated values restored to their original types
+ */
 export function applyValueAnnotations(
   plain: any,
   annotations: MinimisedTree<TypeAnnotation>,
@@ -78,12 +93,25 @@ export function applyValueAnnotations(
   return plain;
 }
 
+/**
+ * Restores referential equality between object paths that shared the same identity before serialization,
+ * ensuring that paths which pointed to the same object reference are reconnected after deserialization.
+ * @param plain - The deserialized plain object to restore shared references in
+ * @param annotations - Mapping of representative paths to arrays of paths that should share the same reference
+ * @param version - Serialization version for path parsing compatibility
+ * @returns The object with referential equalities restored
+ */
 export function applyReferentialEqualityAnnotations(
   plain: any,
   annotations: ReferentialEqualityAnnotations,
   version: number
 ) {
   const legacyPaths = enableLegacyPaths(version);
+  /**
+   * Sets all identical paths to reference the same object found at the given representative path.
+   * @param identicalPaths - Stringified paths that should share the same object reference
+   * @param path - The representative path whose value will be copied to all identical paths
+   */
   function apply(identicalPaths: string[], path: string) {
     const object = getDeep(plain, parsePath(path, legacyPaths));
 
@@ -122,6 +150,13 @@ const isDeep = (object: any, superJson: SuperJSON): boolean =>
   isError(object) ||
   isInstanceOfRegisteredClass(object, superJson);
 
+/**
+ * Tracks an object's occurrence at a given path in the identity map, enabling detection of shared references
+ * so that referential equality can be preserved during serialization.
+ * @param object - The object whose identity is being tracked
+ * @param path - The path segments at which this object was encountered
+ * @param identities - Map from objects to all paths where they appear
+ */
 function addIdentity(object: any, path: any[], identities: Map<any, any[][]>) {
   const existingSet = identities.get(object);
 
@@ -142,6 +177,13 @@ export type ReferentialEqualityAnnotations =
   | [string[]]
   | [string[], Record<string, string[]>];
 
+/**
+ * Builds a compact annotation structure describing which object paths share referential equality,
+ * used during serialization to record shared references so they can be restored on deserialization.
+ * @param identitites - Map from objects to all paths where each object appears
+ * @param dedupe - When true, duplicate objects are removed (only first occurrence kept); when false, paths are sorted by length for readability
+ * @returns A referential equality annotation structure, or undefined if no shared references exist
+ */
 export function generateReferentialEqualityAnnotations(
   identitites: Map<any, any[][]>,
   dedupe: boolean
@@ -185,6 +227,19 @@ export function generateReferentialEqualityAnnotations(
   }
 }
 
+/**
+ * Recursively transforms a value and all nested values into a plain serializable form,
+ * collecting type annotations and tracking object identities for referential equality preservation.
+ * @param object - The value to transform
+ * @param identities - Map tracking object identities across all paths for shared-reference detection
+ * @param superJson - The SuperJSON instance providing registered custom transformers
+ * @param dedupe - Whether to deduplicate repeated object references (replacing duplicates with null)
+ * @param path - Current path segments within the root object
+ * @param objectsInThisPath - Objects encountered along the current traversal path, used for circular reference detection
+ * @param seenObjects - Cache of previously transformed objects to avoid redundant work
+ * @returns The transformed value along with any type annotations needed for deserialization
+ * @throws Error if a prototype-polluting property name (__proto__, constructor, prototype) is encountered
+ */
 export const walker = (
   object: any,
   identities: Map<any, any[][]>,


### PR DESCRIPTION
## Add JSDoc documentation in src/plainer.ts

**Category:** `docs` | **Contributor:** test-agent

Closes #9

### Changes
Add JSDoc documentation for 9 item(s) in src/plainer.ts.

### Diagnostics addressed
- `src/plainer.ts:30` jsdoc/require-jsdoc: Missing JSDoc comment.
- `src/plainer.ts:64` jsdoc/require-jsdoc: Missing JSDoc comment.
- `src/plainer.ts:64` jsdoc/require-jsdoc: Missing JSDoc comment.
- `src/plainer.ts:81` jsdoc/require-jsdoc: Missing JSDoc comment.
- `src/plainer.ts:81` jsdoc/require-jsdoc: Missing JSDoc comment.
- `src/plainer.ts:87` jsdoc/require-jsdoc: Missing JSDoc comment.
- `src/plainer.ts:125` jsdoc/require-jsdoc: Missing JSDoc comment.
- `src/plainer.ts:145` jsdoc/require-jsdoc: Missing JSDoc comment.
- `src/plainer.ts:145` jsdoc/require-jsdoc: Missing JSDoc comment.

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*