### PR TITLE
test: Write failing tests for BigInt64Array and BigUint64Array support

### DIFF
--- a/src/is.test.ts
+++ b/src/is.test.ts
@@ -92,3 +92,15 @@ test('Regression: null-prototype object', () => {
   expect(isPlainObject(Object.create(null))).toBe(true);
   expect(isPrimitive(Object.create(null))).toBe(false);
 });
+
+test('isTypedArray returns true for BigInt64Array', () => {
+  expect(isTypedArray(new BigInt64Array())).toBe(true);
+  expect(isTypedArray(new BigInt64Array([1n, 2n, 3n]))).toBe(true);
+  expect(isTypedArray(BigInt64Array.of(0n))).toBe(true);
+});
+
+test('isTypedArray returns true for BigUint64Array', () => {
+  expect(isTypedArray(new BigUint64Array())).toBe(true);
+  expect(isTypedArray(new BigUint64Array([1n, 2n, 3n]))).toBe(true);
+  expect(isTypedArray(BigUint64Array.of(0n))).toBe(true);
+});

--- a/src/transformer.test.ts
+++ b/src/transformer.test.ts
@@ -26,3 +26,35 @@ test('throws an descriptive error when transforming', () => {
     `Trying to deserialize unknown class 'NotRegistered' - check https://github.com/blitz-js/superjson/issues/116#issuecomment-773996564`
   );
 });
+
+test('BigInt64Array round-trips through serialize/deserialize', () => {
+  const input = BigInt64Array.of(1n, 2n, 3n);
+  const { json, meta } = SuperJSON.serialize(input);
+  const output = SuperJSON.deserialize<BigInt64Array>({ json, meta });
+  expect(output).toBeInstanceOf(BigInt64Array);
+  expect(output).toEqual(BigInt64Array.of(1n, 2n, 3n));
+});
+
+test('BigUint64Array round-trips through serialize/deserialize', () => {
+  const input = BigUint64Array.of(1n, 2n, 3n);
+  const { json, meta } = SuperJSON.serialize(input);
+  const output = SuperJSON.deserialize<BigUint64Array>({ json, meta });
+  expect(output).toBeInstanceOf(BigUint64Array);
+  expect(output).toEqual(BigUint64Array.of(1n, 2n, 3n));
+});
+
+test('Empty BigInt64Array round-trips through serialize/deserialize', () => {
+  const input = new BigInt64Array();
+  const { json, meta } = SuperJSON.serialize(input);
+  const output = SuperJSON.deserialize<BigInt64Array>({ json, meta });
+  expect(output).toBeInstanceOf(BigInt64Array);
+  expect(output.length).toBe(0);
+});
+
+test('BigInt64Array nested in object round-trips through serialize/deserialize', () => {
+  const input = { data: BigInt64Array.of(10n, 20n) };
+  const { json, meta } = SuperJSON.serialize(input);
+  const output = SuperJSON.deserialize<{ data: BigInt64Array }>({ json, meta });
+  expect(output.data).toBeInstanceOf(BigInt64Array);
+  expect(output.data).toEqual(BigInt64Array.of(10n, 20n));
+});


### PR DESCRIPTION
## Write failing tests for BigInt64Array and BigUint64Array support

**Category:** `test` | **Contributor:** test-agent

Closes #265

### Changes
Add tests that verify BigInt64Array and BigUint64Array are recognized by isTypedArray, included in TypedArrayConstructor, and can round-trip through serialize/deserialize. Specifically: (1) In is.test.ts, add tests that isTypedArray returns true for BigInt64Array and BigUint64Array instances. (2) In transformer.test.ts, add tests that SuperJSON.serialize and SuperJSON.deserialize correctly round-trip BigInt64Array and BigUint64Array values (e.g., BigInt64Array.of(1n, 2n, 3n)). These tests should FAIL currently because the constructors are missing from TypedArrayConstructor and constructorToName.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*