### PR TITLE
test: Write failing tests for BigInt64Array and BigUint64Array support

### DIFF
--- a/src/is.test.ts
+++ b/src/is.test.ts
@@ -12,6 +12,7 @@ import {
   isPlainObject,
   isTypedArray,
   isURL,
+  TypedArrayConstructor,
 } from './is.js';
 
 import { test, expect } from 'vitest';
@@ -91,4 +92,45 @@ test('Date exception', () => {
 test('Regression: null-prototype object', () => {
   expect(isPlainObject(Object.create(null))).toBe(true);
   expect(isPrimitive(Object.create(null))).toBe(false);
+});
+
+test('isTypedArray returns true for BigInt64Array and BigUint64Array', () => {
+  expect(isTypedArray(new BigInt64Array())).toBe(true);
+  expect(isTypedArray(new BigUint64Array())).toBe(true);
+  expect(isTypedArray(BigInt64Array.of(1n, 2n, 3n))).toBe(true);
+  expect(isTypedArray(BigUint64Array.of(1n, 2n, 3n))).toBe(true);
+});
+
+test('TypedArrayConstructor type should include BigInt64ArrayConstructor and BigUint64ArrayConstructor', () => {
+  // BigInt typed array constructors should be part of the TypedArrayConstructor union.
+  // We verify this by checking that the union covers all typed array constructor names.
+  const expectedNames = [
+    'Int8Array',
+    'Uint8Array',
+    'Uint8ClampedArray',
+    'Int16Array',
+    'Uint16Array',
+    'Int32Array',
+    'Uint32Array',
+    'Float32Array',
+    'Float64Array',
+    'BigInt64Array',
+    'BigUint64Array',
+  ];
+
+  const knownConstructors: TypedArrayConstructor[] = [
+    Int8Array,
+    Uint8Array,
+    Uint8ClampedArray,
+    Int16Array,
+    Uint16Array,
+    Int32Array,
+    Uint32Array,
+    Float32Array,
+    Float64Array,
+  ];
+
+  const knownNames = knownConstructors.map(c => c.name);
+  // This will fail until BigInt64Array and BigUint64Array are added to TypedArrayConstructor
+  expect(knownNames).toEqual(expectedNames);
 });

--- a/src/transformer.test.ts
+++ b/src/transformer.test.ts
@@ -1,6 +1,6 @@
 import SuperJSON from './index.js';
 
-import { test, expect } from 'vitest';
+import { test, expect, describe } from 'vitest';
 
 test('throws an descriptive error when transforming', () => {
   const instance = new SuperJSON();
@@ -25,4 +25,42 @@ test('throws an descriptive error when transforming', () => {
   ).toThrowError(
     `Trying to deserialize unknown class 'NotRegistered' - check https://github.com/blitz-js/superjson/issues/116#issuecomment-773996564`
   );
+});
+
+describe('BigInt typed array serialization', () => {
+  test('SuperJSON serializes and deserializes BigInt64Array', () => {
+    const input = { a: BigInt64Array.of(1n, 2n, 3n) };
+    const { json, meta } = SuperJSON.serialize(input);
+
+    expect(meta?.values).toEqual({ a: [['typed-array', 'BigInt64Array']] });
+
+    const output = SuperJSON.deserialize<typeof input>({ json, meta });
+    expect(output.a).toBeInstanceOf(BigInt64Array);
+    expect(Array.from(output.a)).toEqual([1n, 2n, 3n]);
+  });
+
+  test('SuperJSON serializes and deserializes BigUint64Array', () => {
+    const input = { a: BigUint64Array.of(1n, 2n, 3n) };
+    const { json, meta } = SuperJSON.serialize(input);
+
+    expect(meta?.values).toEqual({ a: [['typed-array', 'BigUint64Array']] });
+
+    const output = SuperJSON.deserialize<typeof input>({ json, meta });
+    expect(output.a).toBeInstanceOf(BigUint64Array);
+    expect(Array.from(output.a)).toEqual([1n, 2n, 3n]);
+  });
+
+  test('SuperJSON round-trips empty BigInt typed arrays', () => {
+    const input = {
+      a: new BigInt64Array(),
+      b: new BigUint64Array(),
+    };
+    const output = SuperJSON.deserialize<typeof input>(
+      SuperJSON.serialize(input)
+    );
+    expect(output.a).toBeInstanceOf(BigInt64Array);
+    expect(output.b).toBeInstanceOf(BigUint64Array);
+    expect(output.a.length).toBe(0);
+    expect(output.b.length).toBe(0);
+  });
 });


### PR DESCRIPTION
## Write failing tests for BigInt64Array and BigUint64Array support

**Category:** `test` | **Contributor:** test-agent

Closes #261

### Changes
Add tests covering BigInt64Array and BigUint64Array:

1. In `src/is.test.ts`: Add tests that `isTypedArray` returns true for BigInt64Array and BigUint64Array instances. Verify the TypedArrayConstructor type accepts these constructors.

2. In `src/transformer.test.ts`: Add tests that SuperJSON can serialize and deserialize BigInt64Array and BigUint64Array values round-trip. Test with sample data like `BigInt64Array.of(1n, 2n, 3n)` and `BigUint64Array.of(1n, 2n, 3n)`. Verify the serialized meta contains `['typed-array', 'BigInt64Array']` and `['typed-array', 'BigUint64Array']` annotations respectively.

These tests should FAIL because the constructors are not yet in the TypedArrayConstructor union, constructorToName map, or nameToConstructor map.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*