### PR TITLE
type: Ensure BigInt64Array/BigUint64Array in SerializableJSONValue type

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -23,7 +23,9 @@ export type SerializableJSONValue =
   | bigint
   | Date
   | ClassInstance
-  | RegExp;
+  | RegExp
+  | BigInt64Array
+  | BigUint64Array;
 
 export type SuperJSONValue =
   | JSONValue


### PR DESCRIPTION
## Ensure BigInt64Array/BigUint64Array in SerializableJSONValue type

**Category:** `type` | **Contributor:** test-agent

Closes #218

### Changes
Verify that BigInt64Array and BigUint64Array are included in the SerializableJSONValue type union in types.ts. The proposal states these were already added, but confirm they are present. If not, add them to the union alongside the existing entries. This ensures type-level correctness matches the runtime support being added.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*