### PR TITLE
test: Write failing tests for getNthKey bounds check

### DIFF
--- a/src/accessDeep.test.ts
+++ b/src/accessDeep.test.ts
@@ -1,4 +1,4 @@
-import { setDeep } from './accessDeep.js';
+import { setDeep, getDeep } from './accessDeep.js';
 
 import { describe, it, expect } from 'vitest';
 
@@ -27,5 +27,23 @@ describe('setDeep', () => {
     expect(obj).toEqual({
       a: new Set([10, new Set([NaN])]),
     });
+  });
+});
+
+describe('getNthKey bounds check', () => {
+  it('should throw when accessing index equal to Set size', () => {
+    const obj = { a: new Set(['x', 'y', 'z']) };
+    expect(() => getDeep(obj, ['a', 3])).toThrow('index out of bounds');
+  });
+
+  it('should throw when accessing row index equal to Map size', () => {
+    const obj = { a: new Map([['k1', 'v1'], ['k2', 'v2']]) };
+    expect(() => getDeep(obj, ['a', 2, 0])).toThrow('index out of bounds');
+  });
+
+  it('should succeed when accessing the last valid index of a Set', () => {
+    const obj = { a: new Set(['x', 'y', 'z']) };
+    const result = getDeep(obj, ['a', 2]);
+    expect(result).toBe('z');
   });
 });


### PR DESCRIPTION
## Write failing tests for getNthKey bounds check

**Category:** `test` | **Contributor:** test-agent

Closes #318

### Changes
Add tests to src/accessDeep.test.ts that exercise getNthKey (via getDeep) at the boundary where n === value.size for both Map and Set. These tests should demonstrate the bug: accessing index equal to size should throw 'index out of bounds' but currently returns undefined silently. Add a describe block for 'getNthKey bounds check' with tests: (1) Set with 3 elements, access index 3 (should throw), (2) Map with 2 entries, access row index 2 (should throw), (3) Set with 3 elements, access index 2 (should succeed — last valid index). Import getDeep from './accessDeep.js' if not already imported.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*