### PR TITLE
test: Write tests for Error stack trace serialization roundtrip

### DIFF
--- a/src/transformer.test.ts
+++ b/src/transformer.test.ts
@@ -26,3 +26,42 @@ test('throws an descriptive error when transforming', () => {
     `Trying to deserialize unknown class 'NotRegistered' - check https://github.com/blitz-js/superjson/issues/116#issuecomment-773996564`
   );
 });
+
+test('Error stack trace survives serialize/deserialize roundtrip', () => {
+  const instance = new SuperJSON();
+  const original = new Error('something went wrong');
+
+  const result = instance.deserialize(instance.serialize(original));
+
+  expect(result).toBeInstanceOf(Error);
+  expect((result as Error).message).toBe('something went wrong');
+  expect((result as Error).stack).toBeDefined();
+  expect(typeof (result as Error).stack).toBe('string');
+  expect((result as Error).stack!.length).toBeGreaterThan(0);
+  expect((result as Error).stack).toBe(original.stack);
+});
+
+test('Error with cause preserves both stack traces through roundtrip', () => {
+  const instance = new SuperJSON();
+  const cause = new Error('root cause');
+  const original = new Error('wrapper error', { cause });
+
+  const result = instance.deserialize(instance.serialize(original));
+
+  expect(result).toBeInstanceOf(Error);
+  const deserialized = result as Error;
+
+  // Outer error stack preserved
+  expect(deserialized.stack).toBeDefined();
+  expect(typeof deserialized.stack).toBe('string');
+  expect(deserialized.stack!.length).toBeGreaterThan(0);
+  expect(deserialized.stack).toBe(original.stack);
+
+  // Cause error stack preserved
+  expect(deserialized.cause).toBeInstanceOf(Error);
+  const deserializedCause = deserialized.cause as Error;
+  expect(deserializedCause.stack).toBeDefined();
+  expect(typeof deserializedCause.stack).toBe('string');
+  expect(deserializedCause.stack!.length).toBeGreaterThan(0);
+  expect(deserializedCause.stack).toBe(cause.stack);
+});


### PR DESCRIPTION
## Write tests for Error stack trace serialization roundtrip

**Category:** `test` | **Contributor:** test-agent

Closes #316

### Changes
Add tests to src/transformer.test.ts that verify Error stack traces survive a serialize/deserialize roundtrip via SuperJSON. Write at least two test cases: (1) a basic Error where after roundtrip the deserialized error has a `.stack` property that is a non-empty string matching the original, and (2) an Error with a `cause` that also has a stack, verifying both stacks are preserved. These tests should FAIL against the current code because `stack` is not serialized in the transform function.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*