### PR TITLE
test: Write tests for BigInt deserialization error when polyfill missing

### DIFF
--- a/src/transformer.test.ts
+++ b/src/transformer.test.ts
@@ -1,6 +1,37 @@
 import SuperJSON from './index.js';
 
-import { test, expect } from 'vitest';
+import { test, expect, describe, vi, afterEach } from 'vitest';
+
+describe('BigInt deserialization when BigInt is unavailable', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  test('deserializing a serialized bigint throws when BigInt is unavailable', () => {
+    const serialized = SuperJSON.serialize(BigInt(42));
+
+    vi.stubGlobal('BigInt', undefined);
+
+    expect(() => SuperJSON.deserialize(serialized)).toThrow();
+  });
+
+  test('the error message mentions BigInt and suggests a polyfill', () => {
+    const serialized = SuperJSON.serialize(BigInt(999));
+
+    vi.stubGlobal('BigInt', undefined);
+
+    expect(() => SuperJSON.deserialize(serialized)).toThrow(/BigInt/);
+    expect(() => SuperJSON.deserialize(serialized)).toThrow(/polyfill/i);
+  });
+
+  test('deserializing a bigint within an object throws when BigInt is unavailable', () => {
+    const serialized = SuperJSON.serialize({ value: BigInt(123) });
+
+    vi.stubGlobal('BigInt', undefined);
+
+    expect(() => SuperJSON.deserialize(serialized)).toThrow();
+  });
+});
 
 test('throws an descriptive error when transforming', () => {
   const instance = new SuperJSON();


### PR DESCRIPTION
## Write tests for BigInt deserialization error when polyfill missing

**Category:** `test` | **Contributor:** test-agent

Closes #314

### Changes
Add tests to src/transformer.test.ts that verify BigInt deserialization throws an error (not returns a string) when BigInt is unavailable. Mock `typeof BigInt === 'undefined'` or the relevant untransform path to simulate a missing BigInt polyfill. Test that: (1) deserializing a serialized bigint value throws a descriptive error when BigInt is unavailable, (2) the error message mentions BigInt and suggests a polyfill. The tests should currently FAIL because the existing code returns a string instead of throwing.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*