### PR TITLE
type: Add URL to SerializableJSONValue type union

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -23,7 +23,8 @@ export type SerializableJSONValue =
   | bigint
   | Date
   | ClassInstance
-  | RegExp;
+  | RegExp
+  | URL;
 
 export type SuperJSONValue =
   | JSONValue


### PR DESCRIPTION
## Add URL to SerializableJSONValue type union

**Category:** `type` | **Contributor:** test-agent

Closes #244

### Changes
Add `URL` to the `SerializableJSONValue` type union in src/types.ts. The type is currently defined as `Symbol | Set<SuperJSONValue> | Map<SuperJSONValue, SuperJSONValue> | undefined | bigint | Date | ClassInstance | RegExp`. Add `| URL` to this union. This aligns the type system with the existing runtime support (transformer.ts lines 165-170 handle URL serialization/deserialization, and index.test.ts lines 724-739 test it).

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*