### PR TITLE
test: Write tests proving Error stack is overwritten with undefined

### DIFF
--- a/src/transformer.test.ts
+++ b/src/transformer.test.ts
@@ -26,3 +26,28 @@ test('throws an descriptive error when transforming', () => {
     `Trying to deserialize unknown class 'NotRegistered' - check https://github.com/blitz-js/superjson/issues/116#issuecomment-773996564`
   );
 });
+
+test('round-tripped Error preserves a non-empty stack string', () => {
+  const instance = new SuperJSON();
+  const original = new Error('something went wrong');
+  const { json, meta } = instance.serialize(original);
+  const deserialized = instance.deserialize<Error>({ json, meta });
+
+  expect(deserialized).toBeInstanceOf(Error);
+  expect(deserialized.message).toBe('something went wrong');
+  expect(typeof deserialized.stack).toBe('string');
+  expect(deserialized.stack).toBeTruthy();
+});
+
+test('round-tripped TypeError preserves a non-empty stack string', () => {
+  const instance = new SuperJSON();
+  const original = new TypeError('bad type');
+  const { json, meta } = instance.serialize(original);
+  const deserialized = instance.deserialize<TypeError>({ json, meta });
+
+  expect(deserialized).toBeInstanceOf(Error);
+  expect(deserialized.name).toBe('TypeError');
+  expect(deserialized.message).toBe('bad type');
+  expect(typeof deserialized.stack).toBe('string');
+  expect(deserialized.stack).toBeTruthy();
+});


### PR DESCRIPTION
## Write tests proving Error stack is overwritten with undefined

**Category:** `test` | **Contributor:** test-agent

Closes #330

### Changes
Add tests to src/transformer.test.ts that demonstrate the bug: when an Error is serialized and deserialized via SuperJSON, the deserialized Error's stack property should be a non-empty string (a real stack trace), not undefined. Write at least two tests: (1) round-trip an Error and assert that the deserialized error has a truthy `.stack` that is a string, (2) round-trip an Error subclass (e.g. TypeError) and verify `.stack` is preserved. These tests should FAIL against the current code because `e.stack = v.stack` overwrites the real stack with undefined.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*