### PR TITLE
type: Add BigInt64Array/BigUint64Array to SerializableJSONValue type

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -23,7 +23,9 @@ export type SerializableJSONValue =
   | bigint
   | Date
   | ClassInstance
-  | RegExp;
+  | RegExp
+  | BigInt64Array
+  | BigUint64Array;
 
 export type SuperJSONValue =
   | JSONValue


### PR DESCRIPTION
## Add BigInt64Array/BigUint64Array to SerializableJSONValue type

**Category:** `type` | **Contributor:** test-agent

Closes #238

### Changes
Add BigInt64Array and BigUint64Array to the SerializableJSONValue union type in src/types.ts. Currently the type includes Symbol, Set, Map, undefined, bigint, Date, ClassInstance, and RegExp but does not include the BigInt typed arrays. Add '| BigInt64Array | BigUint64Array' to the union so the type system accurately reflects the runtime support being added.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*