### PR TITLE
test: Write failing tests for BigInt untransform throwing on missing BigInt

### DIFF
--- a/src/transformer.test.ts
+++ b/src/transformer.test.ts
@@ -1,6 +1,56 @@
 import SuperJSON from './index.js';
+import { untransformValue } from './transformer.js';
 
-import { test, expect } from 'vitest';
+import { test, expect, describe, afterEach } from 'vitest';
+
+describe('BigInt untransform', () => {
+  const originalBigInt = globalThis.BigInt;
+
+  afterEach(() => {
+    globalThis.BigInt = originalBigInt;
+  });
+
+  test('throws a descriptive error when BigInt is not available', () => {
+    Object.defineProperty(globalThis, 'BigInt', { value: undefined, configurable: true, writable: true });
+
+    const superJson = new SuperJSON();
+
+    expect(() => {
+      untransformValue('123', 'bigint', superJson);
+    }).toThrowError(/BigInt/);
+  });
+
+  test('throws when BigInt is not available for deserialization via SuperJSON.deserialize', () => {
+    const superJson = new SuperJSON();
+
+    // Serialize while BigInt is available
+    const serialized = superJson.serialize(BigInt(42));
+
+    // Now remove BigInt
+    Object.defineProperty(globalThis, 'BigInt', { value: undefined, configurable: true, writable: true });
+
+    expect(() => {
+      superJson.deserialize(serialized);
+    }).toThrowError(/BigInt/);
+  });
+
+  test('correctly roundtrips bigint values when BigInt is available', () => {
+    const superJson = new SuperJSON();
+    const value = BigInt('9007199254740993');
+    const serialized = superJson.serialize(value);
+    const deserialized = superJson.deserialize<bigint>(serialized);
+    expect(deserialized).toBe(value);
+  });
+
+  test('correctly roundtrips bigint inside objects when BigInt is available', () => {
+    const superJson = new SuperJSON();
+    const obj = { count: BigInt(0), large: BigInt('-999999999999999999') };
+    const serialized = superJson.serialize(obj);
+    const deserialized = superJson.deserialize<typeof obj>(serialized);
+    expect(deserialized.count).toBe(BigInt(0));
+    expect(deserialized.large).toBe(BigInt('-999999999999999999'));
+  });
+});
 
 test('throws an descriptive error when transforming', () => {
   const instance = new SuperJSON();


### PR DESCRIPTION
## Write failing tests for BigInt untransform throwing on missing BigInt

**Category:** `test` | **Contributor:** test-agent

Closes #347

### Changes
Add tests to src/transformer.test.ts that verify: when BigInt is not available at runtime, calling untransform for a bigint-annotated value throws an Error (not returns a string). Mock globalThis.BigInt to undefined for the test scope. The error message should be descriptive (e.g., mention BigInt not being available). Also verify that when BigInt IS available, deserialization works correctly (roundtrip test). The new tests should currently FAIL because the implementation still does console.error + return string.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*