### PR TITLE
test: Write failing tests for getNthKey bounds check

### DIFF
--- a/src/accessDeep.test.ts
+++ b/src/accessDeep.test.ts
@@ -1,4 +1,4 @@
-import { setDeep } from './accessDeep.js';
+import { getDeep, setDeep } from './accessDeep.js';
 
 import { describe, it, expect } from 'vitest';
 
@@ -27,5 +27,58 @@ describe('setDeep', () => {
     expect(obj).toEqual({
       a: new Set([10, new Set([NaN])]),
     });
+  });
+});
+
+describe('getNthKey bounds checking', () => {
+  it('throws when accessing index === set.size via getDeep', () => {
+    const set = new Set(['a', 'b', 'c']);
+    expect(() => getDeep(set, [3])).toThrow('index out of bounds');
+  });
+
+  it('throws when accessing index === map.size via getDeep', () => {
+    const map = new Map([
+      ['x', 1],
+      ['y', 2],
+    ]);
+    expect(() => getDeep(map, [2, 0])).toThrow('index out of bounds');
+  });
+
+  it('throws when passing a negative index on a Set via getDeep', () => {
+    const set = new Set(['a', 'b']);
+    expect(() => getDeep(set, [-1])).toThrow('index out of bounds');
+  });
+
+  it('throws when passing a negative index on a Map via getDeep', () => {
+    const map = new Map([['x', 1]]);
+    expect(() => getDeep(map, [-1, 0])).toThrow('index out of bounds');
+  });
+
+  it('throws when accessing index === set.size via setDeep', () => {
+    const set = new Set(['a', 'b', 'c']);
+    expect(() => setDeep(set, [3], v => v)).toThrow('index out of bounds');
+  });
+
+  it('throws when accessing index === map.size via setDeep', () => {
+    const map = new Map([
+      ['x', 1],
+      ['y', 2],
+    ]);
+    expect(() => setDeep(map, [2, 0], v => v)).toThrow('index out of bounds');
+  });
+
+  it('succeeds when accessing valid indices on a Set', () => {
+    const set = new Set(['a', 'b', 'c']);
+    expect(getDeep(set, [0])).toBe('a');
+    expect(getDeep(set, [2])).toBe('c');
+  });
+
+  it('succeeds when accessing valid indices on a Map', () => {
+    const map = new Map([
+      ['x', 10],
+      ['y', 20],
+    ]);
+    expect(getDeep(map, [0, 0])).toBe('x');
+    expect(getDeep(map, [1, 1])).toBe(20);
   });
 });


### PR DESCRIPTION
## Write failing tests for getNthKey bounds check

**Category:** `test` | **Contributor:** test-agent

Closes #340

### Changes
Add tests to src/accessDeep.test.ts that exercise the getNthKey bounds via getDeep/setDeep. Test cases: (1) accessing index === set.size on a Set should throw 'index out of bounds', (2) accessing index === map.size on a Map should throw, (3) passing a negative index should throw, (4) accessing valid indices (0, size-1) should succeed. Import getDeep alongside setDeep. Use expect(...).toThrow('index out of bounds') for error cases.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*