### PR TITLE
test: Write failing tests for setDeep with length-1 Map paths

### DIFF
--- a/src/accessDeep.test.ts
+++ b/src/accessDeep.test.ts
@@ -28,4 +28,24 @@ describe('setDeep', () => {
       a: new Set([10, new Set([NaN])]),
     });
   });
+
+  it('throws an informative error when setDeep is called on a Map with a path of length 1', () => {
+    const myMap = new Map([['a', 1], ['b', 2]]);
+    expect(() => setDeep(myMap, [0], v => v)).toThrow(
+      'Map paths in setDeep require at least 2 elements'
+    );
+  });
+
+  it('throws when setDeep targets a nested Map with a single remaining path element', () => {
+    const obj = { m: new Map([['x', 10]]) };
+    expect(() => setDeep(obj, ['m', 0], v => v)).toThrow(
+      'Map paths in setDeep require at least 2 elements'
+    );
+  });
+
+  it('handles setDeep on a Set with path length 1 (regression guard)', () => {
+    const mySet = new Set(['hello', 'world']);
+    setDeep(mySet, [0], v => v.toUpperCase());
+    expect(mySet).toEqual(new Set(['HELLO', 'world']));
+  });
 });


### PR DESCRIPTION
## Write failing tests for setDeep with length-1 Map paths

**Category:** `test` | **Contributor:** test-agent

Closes #349

### Changes
Add test cases to the existing setDeep describe block in src/accessDeep.test.ts that exercise the bug: calling setDeep on an object containing a Map with a path of length 1 (e.g. setDeep(myMap, [0], transformer) where myMap is a Map). The test should verify that either (a) an informative error is thrown explaining Map paths require at least 2 elements, or (b) the operation handles the edge case gracefully. Also add a test with path length 1 targeting a Set (which should work fine) as a regression guard. The tests MUST fail currently because the guard doesn't exist yet.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*