### PR TITLE
test: Write failing tests for circular Error.cause detection

### DIFF
--- a/src/transformer.test.ts
+++ b/src/transformer.test.ts
@@ -1,6 +1,57 @@
 import SuperJSON from './index.js';
 
-import { test, expect } from 'vitest';
+import { test, expect, describe } from 'vitest';
+
+describe('circular Error.cause', () => {
+  test('self-referencing: e.cause = e does not hang or throw stack overflow', () => {
+    const e = new Error('self');
+    e.cause = e;
+
+    const { json, meta } = SuperJSON.serialize(e);
+    const deserialized = SuperJSON.deserialize<Error>({ json, meta });
+
+    expect(deserialized).toBeInstanceOf(Error);
+    expect(deserialized.message).toBe('self');
+    // The cause should reference back to itself (circular)
+    expect(deserialized.cause).toBe(deserialized);
+  });
+
+  test('mutual cycle: e1.cause = e2, e2.cause = e1 does not hang or throw stack overflow', () => {
+    const e1 = new Error('first');
+    const e2 = new Error('second');
+    e1.cause = e2;
+    e2.cause = e1;
+
+    const { json, meta } = SuperJSON.serialize(e1);
+    const deserialized = SuperJSON.deserialize<Error>({ json, meta });
+
+    expect(deserialized).toBeInstanceOf(Error);
+    expect(deserialized.message).toBe('first');
+
+    const cause = deserialized.cause as Error;
+    expect(cause).toBeInstanceOf(Error);
+    expect(cause.message).toBe('second');
+
+    // The cycle should be preserved
+    expect(cause.cause).toBe(deserialized);
+  });
+
+  test('non-circular cause round-trips correctly (regression guard)', () => {
+    const inner = new Error('inner');
+    const outer = new Error('outer', { cause: inner });
+
+    const { json, meta } = SuperJSON.serialize(outer);
+    const deserialized = SuperJSON.deserialize<Error>({ json, meta });
+
+    expect(deserialized).toBeInstanceOf(Error);
+    expect(deserialized.message).toBe('outer');
+
+    const cause = deserialized.cause as Error;
+    expect(cause).toBeInstanceOf(Error);
+    expect(cause.message).toBe('inner');
+    expect(cause.cause).toBeUndefined();
+  });
+});
 
 test('throws an descriptive error when transforming', () => {
   const instance = new SuperJSON();


### PR DESCRIPTION
## Write failing tests for circular Error.cause detection

**Category:** `test` | **Contributor:** test-agent

Closes #334

### Changes
Add tests to src/transformer.test.ts that cover circular Error.cause references. Tests should include: (1) an Error where e.cause = e (self-referencing), (2) an Error chain where e1.cause = e2, e2.cause = e1 (mutual cycle), (3) an Error with a normal non-circular cause (regression guard — should still serialize/deserialize correctly). Use SuperJSON.serialize() and SuperJSON.deserialize() and verify that circular cause cases do not hang or throw stack overflow, and that the round-trip produces the correct structure. These tests should FAIL against the current codebase because the circular reference in Error.cause is not detected.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*