### PR TITLE
test: Write failing test for bigint identity tracking in plainer

### DIFF
--- a/src/plainer.spec.ts
+++ b/src/plainer.spec.ts
@@ -1,5 +1,8 @@
 import SuperJSON from './index.js';
-import { walker } from './plainer.js';
+import {
+  walker,
+  generateReferentialEqualityAnnotations,
+} from './plainer.js';
 
 import { test, expect } from 'vitest';
 
@@ -29,4 +32,46 @@ test('walker', () => {
       b: ['regexp'],
     },
   });
+});
+
+test('bigint values should not trigger identity tracking', () => {
+  const identities = new Map<unknown, unknown[][]>();
+  const superJson = new SuperJSON();
+
+  const input = {
+    x: 1n,
+    y: 1n,
+    z: 999999999999999999n,
+  };
+
+  walker(input, identities, superJson, false);
+
+  // bigints are primitives and should not be added to identity tracking.
+  // Only the root object itself should appear in identities, not the bigint values.
+  const trackedValues = [...identities.keys()];
+  const bigintTracked = trackedValues.filter(v => typeof v === 'bigint');
+  expect(bigintTracked).toEqual([]);
+});
+
+test('duplicate bigint values should not produce referential equality annotations', () => {
+  const identities = new Map<unknown, unknown[][]>();
+  const superJson = new SuperJSON();
+
+  const sameBigint = 42n;
+  const input = {
+    a: sameBigint,
+    b: sameBigint,
+    c: sameBigint,
+  };
+
+  walker(input, identities, superJson, false);
+
+  const refAnnotations = generateReferentialEqualityAnnotations(
+    identities,
+    false
+  );
+
+  // bigints are value types — identical bigint values in different properties
+  // should NOT generate referential equality annotations
+  expect(refAnnotations).toBeUndefined();
 });


### PR DESCRIPTION
## Write failing test for bigint identity tracking in plainer

**Category:** `test` | **Contributor:** test-agent

Closes #103

### Changes
Add a test to src/plainer.spec.ts that verifies bigint values are treated as primitives by the walker — i.e., they should NOT trigger addIdentity tracking. Create a test case where the walker processes an object containing bigint values and confirm the output handles them correctly without identity refs. This test should FAIL because isPrimitive currently excludes bigint.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*