### PR TITLE
test: Write failing tests for plainer bigint round-trip

### DIFF
--- a/src/plainer.spec.ts
+++ b/src/plainer.spec.ts
@@ -30,3 +30,95 @@ test('walker', () => {
     },
   });
 });
+
+test('walker handles bigint inside an object', () => {
+  const identities = new Map();
+  const result = walker(
+    { value: BigInt(42) },
+    identities,
+    new SuperJSON(),
+    false
+  );
+
+  expect(result.transformedValue).toEqual({ value: '42' });
+  expect(result.annotations).toEqual({
+    value: ['bigint'],
+  });
+});
+
+test('walker handles bigint as a top-level primitive', () => {
+  const identities = new Map();
+  const result = walker(BigInt(0), identities, new SuperJSON(), false);
+
+  expect(result.transformedValue).toBe('0');
+  expect(result.annotations).toEqual(['bigint']);
+});
+
+test('walker treats bigint as a primitive and does not track identity', () => {
+  const identities = new Map();
+  const bigintValue = BigInt(99);
+  walker(
+    { a: bigintValue, b: bigintValue },
+    identities,
+    new SuperJSON(),
+    false
+  );
+
+  // bigint should be treated as a primitive and not added to identities
+  expect(identities.has(bigintValue)).toBe(false);
+});
+
+test('walker handles large bigint values', () => {
+  const identities = new Map();
+  const result = walker(
+    { big: BigInt('9007199254740993') },
+    identities,
+    new SuperJSON(),
+    false
+  );
+
+  expect(result.transformedValue).toEqual({ big: '9007199254740993' });
+  expect(result.annotations).toEqual({
+    big: ['bigint'],
+  });
+});
+
+test('walker handles negative bigint', () => {
+  const identities = new Map();
+  const result = walker(
+    { neg: BigInt(-123) },
+    identities,
+    new SuperJSON(),
+    false
+  );
+
+  expect(result.transformedValue).toEqual({ neg: '-123' });
+  expect(result.annotations).toEqual({
+    neg: ['bigint'],
+  });
+});
+
+test('walker handles bigint alongside other transformed types', () => {
+  const identities = new Map();
+  const result = walker(
+    {
+      count: BigInt(7),
+      pattern: /abc/i,
+      created: new Date('2024-01-01T00:00:00.000Z'),
+    },
+    identities,
+    new SuperJSON(),
+    false
+  );
+
+  expect(result.transformedValue).toEqual({
+    count: '7',
+    pattern: '/abc/i',
+    created: '2024-01-01T00:00:00.000Z',
+  });
+  expect(result.annotations).toEqual({
+    count: ['bigint'],
+    pattern: ['regexp'],
+    created: ['Date'],
+  });
+});


### PR DESCRIPTION
## Write failing tests for plainer bigint round-trip

**Category:** `test` | **Contributor:** test-agent

Closes #87

### Changes
Add test cases to src/plainer.spec.ts verifying that the walker function correctly handles bigint values as primitives — i.e., bigint values should be transformed via the bigint transformer (producing a string annotation) rather than being walked as composite objects. Test that a bigint value inside an object is correctly annotated with 'bigint' type. If there is also an index.test.ts with end-to-end serialize/deserialize tests for bigint, check those cover this path; if not, add a walker-level test in plainer.spec.ts.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*