### PR TITLE
test: Write failing tests for BigInt64Array/BigUint64Array serialization

### DIFF
--- a/src/is.test.ts
+++ b/src/is.test.ts
@@ -92,3 +92,11 @@ test('Regression: null-prototype object', () => {
   expect(isPlainObject(Object.create(null))).toBe(true);
   expect(isPrimitive(Object.create(null))).toBe(false);
 });
+
+test('isTypedArray recognizes BigInt64Array', () => {
+  expect(isTypedArray(new BigInt64Array([1n]))).toBe(true);
+});
+
+test('isTypedArray recognizes BigUint64Array', () => {
+  expect(isTypedArray(new BigUint64Array([1n]))).toBe(true);
+});

--- a/src/transformer.test.ts
+++ b/src/transformer.test.ts
@@ -2,6 +2,47 @@ import SuperJSON from './index.js';
 
 import { test, expect } from 'vitest';
 
+test('BigInt64Array round-trips through SuperJSON', () => {
+  const instance = new SuperJSON();
+  const input = new BigInt64Array([0n, -1n, 9007199254740993n]);
+  const { json, meta } = instance.serialize(input);
+  const output = instance.deserialize({ json, meta });
+  expect(output).toBeInstanceOf(BigInt64Array);
+  expect(output).toEqual(input);
+});
+
+test('BigUint64Array round-trips through SuperJSON', () => {
+  const instance = new SuperJSON();
+  const input = new BigUint64Array([0n, 1n, 18446744073709551615n]);
+  const { json, meta } = instance.serialize(input);
+  const output = instance.deserialize({ json, meta });
+  expect(output).toBeInstanceOf(BigUint64Array);
+  expect(output).toEqual(input);
+});
+
+test('empty BigInt64Array round-trips through SuperJSON', () => {
+  const instance = new SuperJSON();
+  const input = new BigInt64Array([]);
+  const { json, meta } = instance.serialize(input);
+  const output = instance.deserialize({ json, meta });
+  expect(output).toBeInstanceOf(BigInt64Array);
+  expect(output).toEqual(input);
+});
+
+test('BigInt typed arrays nested in objects round-trip through SuperJSON', () => {
+  const instance = new SuperJSON();
+  const input = {
+    a: new BigInt64Array([1n, 2n]),
+    b: new BigUint64Array([3n, 4n]),
+  };
+  const { json, meta } = instance.serialize(input);
+  const output = instance.deserialize<typeof input>({ json, meta });
+  expect(output.a).toBeInstanceOf(BigInt64Array);
+  expect(output.b).toBeInstanceOf(BigUint64Array);
+  expect(output.a).toEqual(input.a);
+  expect(output.b).toEqual(input.b);
+});
+
 test('throws an descriptive error when transforming', () => {
   const instance = new SuperJSON();
   class FunnyNumber {


### PR DESCRIPTION
## Write failing tests for BigInt64Array/BigUint64Array serialization

**Category:** `test` | **Contributor:** test-agent

Closes #245

### Changes
Add tests that verify BigInt64Array and BigUint64Array are recognized as typed arrays by isTypedArray() in is.ts, and that they round-trip correctly through SuperJSON serialize/deserialize in transformer.ts. For is.test.ts: add test cases asserting isTypedArray(new BigInt64Array([1n])) and isTypedArray(new BigUint64Array([1n])) return true. For transformer.test.ts: add test cases that serialize a BigInt64Array and BigUint64Array via SuperJSON and assert the deserialized result matches the original (similar to how existing typed arrays are tested in index.test.ts). These tests should FAIL because the runtime support doesn't exist yet.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*