### PR TITLE
test: Write tests for BigInt typed array type coverage

### DIFF
--- a/src/is.test.ts
+++ b/src/is.test.ts
@@ -12,6 +12,7 @@ import {
   isPlainObject,
   isTypedArray,
   isURL,
+  TypedArray,
 } from './is.js';
 
 import { test, expect } from 'vitest';
@@ -91,4 +92,18 @@ test('Date exception', () => {
 test('Regression: null-prototype object', () => {
   expect(isPlainObject(Object.create(null))).toBe(true);
   expect(isPrimitive(Object.create(null))).toBe(false);
+});
+
+test('isTypedArray recognizes BigInt typed arrays', () => {
+  expect(isTypedArray(new BigInt64Array())).toBe(true);
+  expect(isTypedArray(new BigUint64Array())).toBe(true);
+  expect(isTypedArray(new BigInt64Array(4))).toBe(true);
+  expect(isTypedArray(new BigUint64Array(4))).toBe(true);
+});
+
+test('TypedArray type includes BigInt typed arrays', () => {
+  const bigInt64: TypedArray = new BigInt64Array();
+  const bigUint64: TypedArray = new BigUint64Array();
+  expect(bigInt64).toBeInstanceOf(BigInt64Array);
+  expect(bigUint64).toBeInstanceOf(BigUint64Array);
 });


### PR DESCRIPTION
## Write tests for BigInt typed array type coverage

**Category:** `test` | **Contributor:** test-agent

Closes #239

### Changes
Add tests to src/is.test.ts that verify BigInt64Array and BigUint64Array are recognized by the isTypedArray type guard and that the narrowed TypedArray type includes bigint element types. Specifically: (1) add test cases that pass BigInt64Array and BigUint64Array instances to isTypedArray and assert they return true, (2) add a type-level test (using ts-expect-error or satisfies) that asserts the TypedArray type includes BigInt64Array and BigUint64Array as valid members of the union. The runtime tests should pass (ArrayBuffer.isView already catches them), but the type-level tests should fail because the TypedArrayConstructor union is missing the BigInt constructors.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*