### PR TITLE
test: Write tests for BigInt64Array/BigUint64Array serialization

### DIFF
--- a/src/transformer.test.ts
+++ b/src/transformer.test.ts
@@ -1,6 +1,88 @@
 import SuperJSON from './index.js';
 
-import { test, expect } from 'vitest';
+import { test, expect, describe } from 'vitest';
+
+describe('BigInt64Array serialization', () => {
+  test('round-trips BigInt64Array', () => {
+    const input = new BigInt64Array([1n, -2n, 3n]);
+    const { json, meta } = SuperJSON.serialize(input);
+
+    expect(meta?.values).toEqual([['typed-array', 'BigInt64Array']]);
+
+    const output = SuperJSON.deserialize<BigInt64Array>({ json, meta });
+    expect(output).toBeInstanceOf(BigInt64Array);
+    expect(output).toEqual(input);
+  });
+
+  test('round-trips empty BigInt64Array', () => {
+    const input = new BigInt64Array([]);
+    const { json, meta } = SuperJSON.serialize(input);
+
+    expect(meta?.values).toEqual([['typed-array', 'BigInt64Array']]);
+
+    const output = SuperJSON.deserialize<BigInt64Array>({ json, meta });
+    expect(output).toBeInstanceOf(BigInt64Array);
+    expect(output.length).toBe(0);
+  });
+});
+
+describe('BigUint64Array serialization', () => {
+  test('round-trips BigUint64Array', () => {
+    const input = new BigUint64Array([0n, 100n, 9007199254740993n]);
+    const { json, meta } = SuperJSON.serialize(input);
+
+    expect(meta?.values).toEqual([['typed-array', 'BigUint64Array']]);
+
+    const output = SuperJSON.deserialize<BigUint64Array>({ json, meta });
+    expect(output).toBeInstanceOf(BigUint64Array);
+    expect(output).toEqual(input);
+  });
+
+  test('round-trips empty BigUint64Array', () => {
+    const input = new BigUint64Array([]);
+    const { json, meta } = SuperJSON.serialize(input);
+
+    expect(meta?.values).toEqual([['typed-array', 'BigUint64Array']]);
+
+    const output = SuperJSON.deserialize<BigUint64Array>({ json, meta });
+    expect(output).toBeInstanceOf(BigUint64Array);
+    expect(output.length).toBe(0);
+  });
+});
+
+describe('BigInt typed arrays in nested objects', () => {
+  test('round-trips nested BigInt64Array and BigUint64Array', () => {
+    const input = {
+      signed: new BigInt64Array([-1n, 0n, 1n]),
+      unsigned: new BigUint64Array([42n, 99n]),
+    };
+    const { json, meta } = SuperJSON.serialize(input);
+
+    expect(meta?.values).toEqual({
+      signed: [['typed-array', 'BigInt64Array']],
+      unsigned: [['typed-array', 'BigUint64Array']],
+    });
+
+    const output = SuperJSON.deserialize<typeof input>({ json, meta });
+    expect(output.signed).toBeInstanceOf(BigInt64Array);
+    expect(output.unsigned).toBeInstanceOf(BigUint64Array);
+    expect(output.signed).toEqual(input.signed);
+    expect(output.unsigned).toEqual(input.unsigned);
+  });
+
+  test('round-trips deeply nested BigInt typed arrays', () => {
+    const input = {
+      data: {
+        ids: new BigUint64Array([1n, 2n, 3n]),
+      },
+    };
+    const { json, meta } = SuperJSON.serialize(input);
+
+    const output = SuperJSON.deserialize<typeof input>({ json, meta });
+    expect(output.data.ids).toBeInstanceOf(BigUint64Array);
+    expect(output.data.ids).toEqual(input.data.ids);
+  });
+});
 
 test('throws an descriptive error when transforming', () => {
   const instance = new SuperJSON();


### PR DESCRIPTION
## Write tests for BigInt64Array/BigUint64Array serialization

**Category:** `test` | **Contributor:** test-agent

Closes #236

### Changes
Add tests to src/transformer.test.ts that verify SuperJSON can round-trip serialize and deserialize BigInt64Array and BigUint64Array values. Tests should: (1) serialize a BigInt64Array, check the meta annotation is ['typed-array', 'BigInt64Array'], then deserialize and compare; (2) same for BigUint64Array; (3) test nested objects containing these types. Follow the existing test patterns in index.test.ts for typed arrays (search for 'Int8Array' or 'typed-array' for examples). These tests MUST fail initially because constructorToName in transformer.ts does not yet include BigInt64Array/BigUint64Array.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*