### PR TITLE
test: Write failing tests for BigInt64Array/BigUint64Array serialization

### DIFF
--- a/src/transformer.test.ts
+++ b/src/transformer.test.ts
@@ -1,6 +1,60 @@
 import SuperJSON from './index.js';
 
-import { test, expect } from 'vitest';
+import { test, expect, describe } from 'vitest';
+
+describe('BigInt64Array serialization', () => {
+  test('round-trips BigInt64Array with various values', () => {
+    const input = new BigInt64Array([0n, 1n, -1n, 9007199254740993n, -9007199254740993n]);
+    const output = SuperJSON.deserialize<BigInt64Array>(SuperJSON.serialize(input));
+    expect(output).toBeInstanceOf(BigInt64Array);
+    expect(output).toEqual(input);
+  });
+
+  test('round-trips empty BigInt64Array', () => {
+    const input = new BigInt64Array([]);
+    const output = SuperJSON.deserialize<BigInt64Array>(SuperJSON.serialize(input));
+    expect(output).toBeInstanceOf(BigInt64Array);
+    expect(output.length).toBe(0);
+  });
+
+  test('serialized form contains string representations of bigint values', () => {
+    const input = new BigInt64Array([42n, -7n]);
+    const serialized = SuperJSON.serialize(input);
+    const jsonValues = serialized.json as string[];
+    expect(jsonValues).toContain('42');
+    expect(jsonValues).toContain('-7');
+    // Values must be strings since JSON cannot represent bigints
+    jsonValues.forEach(v => {
+      expect(typeof v).toBe('string');
+    });
+  });
+});
+
+describe('BigUint64Array serialization', () => {
+  test('round-trips BigUint64Array with various values', () => {
+    const input = new BigUint64Array([0n, 1n, 18446744073709551615n]);
+    const output = SuperJSON.deserialize<BigUint64Array>(SuperJSON.serialize(input));
+    expect(output).toBeInstanceOf(BigUint64Array);
+    expect(output).toEqual(input);
+  });
+
+  test('round-trips empty BigUint64Array', () => {
+    const input = new BigUint64Array([]);
+    const output = SuperJSON.deserialize<BigUint64Array>(SuperJSON.serialize(input));
+    expect(output).toBeInstanceOf(BigUint64Array);
+    expect(output.length).toBe(0);
+  });
+
+  test('serialized form contains string representations of bigint values', () => {
+    const input = new BigUint64Array([100n]);
+    const serialized = SuperJSON.serialize(input);
+    const jsonValues = serialized.json as string[];
+    expect(jsonValues).toContain('100');
+    jsonValues.forEach(v => {
+      expect(typeof v).toBe('string');
+    });
+  });
+});
 
 test('throws an descriptive error when transforming', () => {
   const instance = new SuperJSON();


### PR DESCRIPTION
## Write failing tests for BigInt64Array/BigUint64Array serialization

**Category:** `test` | **Contributor:** test-agent

Closes #233

### Changes
Add tests to src/transformer.test.ts covering BigInt64Array and BigUint64Array round-trip serialization/deserialization via SuperJSON. Tests should verify: (1) BigInt64Array with various values (positive, negative, zero) serializes and deserializes correctly, (2) BigUint64Array serializes and deserializes correctly, (3) the serialized form contains string representations of bigint values (not raw bigints, since JSON cannot represent bigints), (4) empty BigInt64Array/BigUint64Array round-trip correctly. These tests should FAIL because the current transform logic uses `typeof n === 'number'` and `number[]` casts which don't handle bigint elements.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*