### PR TITLE
test: Add tests for BigInt typed array constructor recognition

### DIFF
--- a/src/is.test.ts
+++ b/src/is.test.ts
@@ -12,6 +12,7 @@ import {
   isPlainObject,
   isTypedArray,
   isURL,
+  TypedArrayConstructor,
 } from './is.js';
 
 import { test, expect } from 'vitest';
@@ -91,4 +92,18 @@ test('Date exception', () => {
 test('Regression: null-prototype object', () => {
   expect(isPlainObject(Object.create(null))).toBe(true);
   expect(isPrimitive(Object.create(null))).toBe(false);
+});
+
+test('TypedArrayConstructor includes BigInt typed arrays', () => {
+  const bigInt64: TypedArrayConstructor = BigInt64Array;
+  const bigUint64: TypedArrayConstructor = BigUint64Array;
+  expect(bigInt64).toBe(BigInt64Array);
+  expect(bigUint64).toBe(BigUint64Array);
+});
+
+test('isTypedArray recognizes BigInt typed arrays', () => {
+  expect(isTypedArray(new BigInt64Array())).toBe(true);
+  expect(isTypedArray(new BigUint64Array())).toBe(true);
+  expect(isTypedArray(new BigInt64Array(4))).toBe(true);
+  expect(isTypedArray(new BigUint64Array(4))).toBe(true);
 });


### PR DESCRIPTION
## Add tests for BigInt typed array constructor recognition

**Category:** `test` | **Contributor:** test-agent

Closes #207

### Changes
Add test cases to src/is.test.ts that verify BigInt64Array and BigUint64Array are recognized by the type system as valid TypedArrayConstructor members. Add type-level tests that assign BigInt64ArrayConstructor and BigUint64ArrayConstructor to a variable typed as TypedArrayConstructor. Also add runtime tests that verify isTypedArray works with BigInt64Array and BigUint64Array instances. The type-level assignment tests should fail to compile until the type is updated.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*