### PR TITLE
test: Write failing tests for BigInt64Array/BigUint64Array serialization

### DIFF
--- a/src/transformer.test.ts
+++ b/src/transformer.test.ts
@@ -1,6 +1,6 @@
 import SuperJSON from './index.js';
 
-import { test, expect } from 'vitest';
+import { test, expect, describe } from 'vitest';
 
 test('throws an descriptive error when transforming', () => {
   const instance = new SuperJSON();
@@ -25,4 +25,70 @@ test('throws an descriptive error when transforming', () => {
   ).toThrowError(
     `Trying to deserialize unknown class 'NotRegistered' - check https://github.com/blitz-js/superjson/issues/116#issuecomment-773996564`
   );
+});
+
+describe('BigInt typed arrays', () => {
+  const instance = new SuperJSON();
+
+  test('round-trips BigInt64Array through serialize/deserialize', () => {
+    const input = new BigInt64Array([1n, -2n, 3n]);
+    const { json, meta } = instance.serialize(input);
+
+    const output = instance.deserialize<BigInt64Array>({ json, meta });
+    expect(output).toBeInstanceOf(BigInt64Array);
+    expect(output.length).toBe(3);
+    expect(output[0]).toBe(1n);
+    expect(output[1]).toBe(-2n);
+    expect(output[2]).toBe(3n);
+  });
+
+  test('round-trips BigUint64Array through serialize/deserialize', () => {
+    const input = new BigUint64Array([1n, 2n, 3n]);
+    const { json, meta } = instance.serialize(input);
+
+    const output = instance.deserialize<BigUint64Array>({ json, meta });
+    expect(output).toBeInstanceOf(BigUint64Array);
+    expect(output.length).toBe(3);
+    expect(output[0]).toBe(1n);
+    expect(output[1]).toBe(2n);
+    expect(output[2]).toBe(3n);
+  });
+
+  test('serialized meta contains typed-array annotation for BigInt64Array', () => {
+    const input = { arr: new BigInt64Array([1n, -2n, 3n]) };
+    const { meta } = instance.serialize(input);
+
+    expect(meta).toBeDefined();
+    expect(meta!.values).toEqual({
+      arr: [['typed-array', 'BigInt64Array']],
+    });
+  });
+
+  test('serialized meta contains typed-array annotation for BigUint64Array', () => {
+    const input = { arr: new BigUint64Array([1n, 2n, 3n]) };
+    const { meta } = instance.serialize(input);
+
+    expect(meta).toBeDefined();
+    expect(meta!.values).toEqual({
+      arr: [['typed-array', 'BigUint64Array']],
+    });
+  });
+
+  test('round-trips empty BigInt64Array', () => {
+    const input = new BigInt64Array([]);
+    const { json, meta } = instance.serialize(input);
+
+    const output = instance.deserialize<BigInt64Array>({ json, meta });
+    expect(output).toBeInstanceOf(BigInt64Array);
+    expect(output.length).toBe(0);
+  });
+
+  test('round-trips empty BigUint64Array', () => {
+    const input = new BigUint64Array([]);
+    const { json, meta } = instance.serialize(input);
+
+    const output = instance.deserialize<BigUint64Array>({ json, meta });
+    expect(output).toBeInstanceOf(BigUint64Array);
+    expect(output.length).toBe(0);
+  });
 });


### PR DESCRIPTION
## Write failing tests for BigInt64Array/BigUint64Array serialization

**Category:** `test` | **Contributor:** test-agent

Closes #204

### Changes
Add tests to src/transformer.test.ts that verify BigInt64Array and BigUint64Array can be round-tripped through SuperJSON serialize/deserialize. Tests should: (1) serialize a BigInt64Array with sample values like [1n, -2n, 3n], then deserialize and check equality, (2) do the same for BigUint64Array with values like [1n, 2n, 3n], (3) verify the serialized meta annotations contain 'typed-array' with the correct constructor name. These tests should FAIL because constructorToName in transformer.ts does not yet include BigInt64Array/BigUint64Array.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*