### PR TITLE
test: Write failing tests for isPrimitive bigint support

### DIFF
--- a/src/is.test.ts
+++ b/src/is.test.ts
@@ -1,5 +1,6 @@
 import {
   isArray,
+  isBigint,
   isBoolean,
   isDate,
   isNull,
@@ -86,6 +87,23 @@ test('Primitive tests', () => {
 
 test('Date exception', () => {
   expect(isDate(new Date('_'))).toBe(false);
+});
+
+test('isPrimitive supports bigint values', () => {
+  expect(isPrimitive(BigInt(0))).toBe(true);
+  expect(isPrimitive(BigInt(123))).toBe(true);
+  expect(isPrimitive(BigInt(-1))).toBe(true);
+  expect(isPrimitive(BigInt(42))).toBe(true);
+});
+
+test('isBigint tests', () => {
+  expect(isBigint(BigInt(0))).toBe(true);
+  expect(isBigint(BigInt(123))).toBe(true);
+  expect(isBigint(BigInt(-1))).toBe(true);
+  expect(isBigint(0)).toBe(false);
+  expect(isBigint('0')).toBe(false);
+  expect(isBigint(null)).toBe(false);
+  expect(isBigint(undefined)).toBe(false);
 });
 
 test('Regression: null-prototype object', () => {


### PR DESCRIPTION
## Write failing tests for isPrimitive bigint support

**Category:** `test` | **Contributor:** test-agent

Closes #195

### Changes
Add test cases to src/is.test.ts that verify isPrimitive returns true for bigint values. Test with BigInt(0), BigInt(123), and BigInt(-1). Also test that the TypeScript return type of isPrimitive includes bigint in its union. These tests should FAIL initially because isPrimitive does not yet check for bigint.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*