### PR TITLE
test: Write failing tests for isPrimitive bigint support

### DIFF
--- a/src/is.test.ts
+++ b/src/is.test.ts
@@ -1,5 +1,6 @@
 import {
   isArray,
+  isBigint,
   isBoolean,
   isDate,
   isNull,
@@ -74,6 +75,12 @@ test('Primitive tests', () => {
   expect(isPrimitive(null)).toBe(true);
   expect(isPrimitive(undefined)).toBe(true);
 
+  // bigint values should be primitive
+  expect(isPrimitive(BigInt(0))).toBe(true);
+  expect(isPrimitive(BigInt(9007199254740991))).toBe(true);
+  expect(isPrimitive(42n)).toBe(true);
+  expect(isPrimitive(-1n)).toBe(true);
+
   expect(isPrimitive(NaN)).toBe(false);
   expect(isPrimitive([])).toBe(false);
   expect(isPrimitive([])).toBe(false);
@@ -82,6 +89,18 @@ test('Primitive tests', () => {
   expect(isPrimitive(new Object())).toBe(false);
   expect(isPrimitive(new Date())).toBe(false);
   expect(isPrimitive(() => {})).toBe(false);
+});
+
+test('Bigint tests', () => {
+  expect(isBigint(BigInt(0))).toBe(true);
+  expect(isBigint(42n)).toBe(true);
+  expect(isBigint(BigInt(9007199254740991))).toBe(true);
+  expect(isBigint(-1n)).toBe(true);
+
+  expect(isBigint(0)).toBe(false);
+  expect(isBigint('42')).toBe(false);
+  expect(isBigint(null)).toBe(false);
+  expect(isBigint(undefined)).toBe(false);
 });
 
 test('Date exception', () => {


### PR DESCRIPTION
## Write failing tests for isPrimitive bigint support

**Category:** `test` | **Contributor:** test-agent

Closes #186

### Changes
Add test cases to src/is.test.ts that verify isPrimitive returns true for bigint values. Add tests such as: isPrimitive(BigInt(0)) should return true, isPrimitive(BigInt(9007199254740991)) should return true, and isPrimitive(42n) should return true. Also verify the return type narrows to include bigint in the union. These tests should FAIL against the current implementation since isPrimitive does not handle bigint yet.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*