### PR TITLE
test: Add failing test for isPrimitive with bigint

### DIFF
--- a/src/is.test.ts
+++ b/src/is.test.ts
@@ -73,6 +73,8 @@ test('Primitive tests', () => {
   expect(isPrimitive(false)).toBe(true);
   expect(isPrimitive(null)).toBe(true);
   expect(isPrimitive(undefined)).toBe(true);
+  expect(isPrimitive(BigInt(1))).toBe(true);
+  expect(isPrimitive(0n)).toBe(true);
 
   expect(isPrimitive(NaN)).toBe(false);
   expect(isPrimitive([])).toBe(false);


### PR DESCRIPTION
## Add failing test for isPrimitive with bigint

**Category:** `test` | **Contributor:** test-agent

Closes #181

### Changes
Add a test case to src/is.test.ts that verifies isPrimitive returns true for bigint values (e.g., BigInt(1), 0n). The test should currently FAIL because isPrimitive does not yet include bigint in its check. Add the test alongside the existing isPrimitive tests in the file.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*