### PR TITLE
test: Write failing tests for isPrimitive with bigint

### DIFF
--- a/src/is.test.ts
+++ b/src/is.test.ts
@@ -13,6 +13,8 @@ import {
   isTypedArray,
   isURL,
 } from './is.js';
+import { walker } from './plainer.js';
+import SuperJSON from './index.js';
 
 import { test, expect } from 'vitest';
 
@@ -91,4 +93,26 @@ test('Date exception', () => {
 test('Regression: null-prototype object', () => {
   expect(isPlainObject(Object.create(null))).toBe(true);
   expect(isPrimitive(Object.create(null))).toBe(false);
+});
+
+test('isPrimitive returns true for bigint values', () => {
+  expect(isPrimitive(BigInt(0))).toBe(true);
+  expect(isPrimitive(BigInt(9007199254740991))).toBe(true);
+  expect(isPrimitive(BigInt(-1))).toBe(true);
+  expect(isPrimitive(42n)).toBe(true);
+  expect(isPrimitive(0n)).toBe(true);
+});
+
+test('walker does not add bigint values to the identity map', () => {
+  const identities = new Map();
+  walker(
+    { a: 42n, b: 42n },
+    identities,
+    new SuperJSON(),
+    false
+  );
+
+  for (const [key] of identities) {
+    expect(typeof key).not.toBe('bigint');
+  }
 });


### PR DESCRIPTION
## Write failing tests for isPrimitive with bigint

**Category:** `test` | **Contributor:** test-agent

Closes #174

### Changes
Add test cases to src/is.test.ts that verify isPrimitive returns true for bigint values. Add cases like isPrimitive(BigInt(0)), isPrimitive(BigInt(9007199254740991)), and isPrimitive(42n) if the environment supports bigint literals. These tests should currently FAIL because isPrimitive does not check for bigint. Also add a test verifying that the walker in plainer.ts does not add bigint values to the identity map (i.e., bigints are treated as primitives and not tracked for deduplication). Follow existing test patterns in the file.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*