### PR TITLE
test: Write failing tests for isPrimitive with bigint

### DIFF
--- a/src/is.test.ts
+++ b/src/is.test.ts
@@ -1,5 +1,6 @@
 import {
   isArray,
+  isBigint,
   isBoolean,
   isDate,
   isNull,
@@ -82,6 +83,28 @@ test('Primitive tests', () => {
   expect(isPrimitive(new Object())).toBe(false);
   expect(isPrimitive(new Date())).toBe(false);
   expect(isPrimitive(() => {})).toBe(false);
+});
+
+test('isPrimitive returns true for bigint values', () => {
+  expect(isPrimitive(BigInt(0))).toBe(true);
+  expect(isPrimitive(BigInt(9007199254740991))).toBe(true);
+  expect(isPrimitive(0n)).toBe(true);
+  expect(isPrimitive(42n)).toBe(true);
+  expect(isPrimitive(BigInt(-1))).toBe(true);
+});
+
+test('isBigint correctly identifies bigint values', () => {
+  expect(isBigint(0n)).toBe(true);
+  expect(isBigint(BigInt(42))).toBe(true);
+  expect(isBigint(0)).toBe(false);
+  expect(isBigint('0')).toBe(false);
+});
+
+test('isPrimitive recognizes bigint as primitive', () => {
+  // bigint is a primitive type in JavaScript; isPrimitive should return true
+  const value: unknown = 0n;
+  const result = isPrimitive(value);
+  expect(result).toBe(true);
 });
 
 test('Date exception', () => {


### PR DESCRIPTION
## Write failing tests for isPrimitive with bigint

**Category:** `test` | **Contributor:** test-agent

Closes #170

### Changes
Add test cases to src/is.test.ts that verify isPrimitive returns true for bigint values. Add tests such as: isPrimitive(BigInt(0)) === true, isPrimitive(BigInt(9007199254740991)) === true, isPrimitive(0n) === true. These tests should FAIL initially because isPrimitive does not yet handle bigint. Also verify the return type narrows to include bigint in the union. Do NOT modify src/is.ts.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*