### PR TITLE
test: Write failing tests for BigInt typed array serialization

### DIFF
--- a/src/transformer.test.ts
+++ b/src/transformer.test.ts
@@ -26,3 +26,51 @@ test('throws an descriptive error when transforming', () => {
     `Trying to deserialize unknown class 'NotRegistered' - check https://github.com/blitz-js/superjson/issues/116#issuecomment-773996564`
   );
 });
+
+test('BigInt64Array round-trips through serialize/deserialize', () => {
+  const instance = new SuperJSON();
+  const value = new BigInt64Array([0n, 1n, -1n, 9007199254740991n]);
+  const serialized = instance.serialize(value);
+  const deserialized = instance.deserialize<BigInt64Array>(serialized);
+  expect(deserialized).toEqual(value);
+  expect(deserialized).toBeInstanceOf(BigInt64Array);
+});
+
+test('BigUint64Array round-trips through serialize/deserialize', () => {
+  const instance = new SuperJSON();
+  const value = new BigUint64Array([0n, 1n, 18446744073709551615n]);
+  const serialized = instance.serialize(value);
+  const deserialized = instance.deserialize<BigUint64Array>(serialized);
+  expect(deserialized).toEqual(value);
+  expect(deserialized).toBeInstanceOf(BigUint64Array);
+});
+
+test('nested objects containing BigInt typed arrays round-trip', () => {
+  const instance = new SuperJSON();
+  const value = {
+    signed: new BigInt64Array([0n, -1n]),
+    unsigned: new BigUint64Array([0n, 1n]),
+    label: 'test',
+  };
+  const serialized = instance.serialize(value);
+  const deserialized = instance.deserialize<typeof value>(serialized);
+  expect(deserialized).toEqual(value);
+  expect(deserialized.signed).toBeInstanceOf(BigInt64Array);
+  expect(deserialized.unsigned).toBeInstanceOf(BigUint64Array);
+});
+
+test('empty BigInt typed arrays round-trip', () => {
+  const instance = new SuperJSON();
+  const signed = new BigInt64Array([]);
+  const unsigned = new BigUint64Array([]);
+
+  const serializedSigned = instance.serialize(signed);
+  const deserializedSigned = instance.deserialize<BigInt64Array>(serializedSigned);
+  expect(deserializedSigned).toEqual(signed);
+  expect(deserializedSigned).toBeInstanceOf(BigInt64Array);
+
+  const serializedUnsigned = instance.serialize(unsigned);
+  const deserializedUnsigned = instance.deserialize<BigUint64Array>(serializedUnsigned);
+  expect(deserializedUnsigned).toEqual(unsigned);
+  expect(deserializedUnsigned).toBeInstanceOf(BigUint64Array);
+});


### PR DESCRIPTION
## Write failing tests for BigInt typed array serialization

**Category:** `test` | **Contributor:** test-agent

Closes #166

### Changes
Add tests to src/transformer.test.ts that verify BigInt64Array and BigUint64Array round-trip through SuperJSON.serialize/deserialize. Tests should cover: (1) a BigInt64Array with sample values like [0n, 1n, -1n, 9007199254740991n], (2) a BigUint64Array with sample values like [0n, 1n, 18446744073709551615n], (3) nested objects containing BigInt typed arrays, (4) empty BigInt typed arrays. Each test should call `instance.serialize(value)` then `instance.deserialize(serialized)` and assert deep equality. Tests MUST import from './index.js' and use vitest's test/expect. Append new tests after the existing test block — do not modify existing tests.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*