### PR TITLE
test: Write failing tests for isPrimitive bigint support

### DIFF
--- a/src/is.test.ts
+++ b/src/is.test.ts
@@ -84,6 +84,23 @@ test('Primitive tests', () => {
   expect(isPrimitive(() => {})).toBe(false);
 });
 
+test('isPrimitive returns true for bigint values', () => {
+  expect(isPrimitive(BigInt(0))).toBe(true);
+  expect(isPrimitive(BigInt(9007199254740991))).toBe(true);
+  expect(isPrimitive(0n)).toBe(true);
+  expect(isPrimitive(9007199254740991n)).toBe(true);
+  expect(isPrimitive(BigInt(-1))).toBe(true);
+});
+
+test('isPrimitive type guard includes bigint', () => {
+  const value = 0n;
+  // isPrimitive should return true for bigint, allowing it to be recognized as primitive
+  expect(isPrimitive(value)).toBe(true);
+  if (isPrimitive(value)) {
+    expect(typeof value).toBe('bigint');
+  }
+});
+
 test('Date exception', () => {
   expect(isDate(new Date('_'))).toBe(false);
 });


### PR DESCRIPTION
## Write failing tests for isPrimitive bigint support

**Category:** `test` | **Contributor:** test-agent

Closes #144

### Changes
Add test cases to src/is.test.ts that verify isPrimitive returns true for bigint values (e.g., BigInt(9007199254740991), 0n). Also add a type-level assertion that isPrimitive's type guard narrows to include bigint. These tests should FAIL against the current implementation since isPrimitive does not yet handle bigint.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*