### PR TITLE
test: Write failing tests for bigint in isPrimitive

### DIFF
--- a/src/is.test.ts
+++ b/src/is.test.ts
@@ -73,6 +73,8 @@ test('Primitive tests', () => {
   expect(isPrimitive(false)).toBe(true);
   expect(isPrimitive(null)).toBe(true);
   expect(isPrimitive(undefined)).toBe(true);
+  expect(isPrimitive(BigInt(42))).toBe(true);
+  expect(isPrimitive(0n)).toBe(true);
 
   expect(isPrimitive(NaN)).toBe(false);
   expect(isPrimitive([])).toBe(false);


### PR DESCRIPTION
## Write failing tests for bigint in isPrimitive

**Category:** `test` | **Contributor:** test-agent

Closes #124

### Changes
Add a test to src/is.test.ts that asserts isPrimitive(BigInt(42)) === true and isPrimitive(0n) === true. These tests should currently FAIL because isPrimitive does not check for bigint. Also add a round-trip test in src/plainer.spec.ts or keep scope to is.test.ts: verify that bigint is recognized as primitive.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*