### PR TITLE
test: Write failing tests for bigint in isPrimitive

### DIFF
--- a/src/is.test.ts
+++ b/src/is.test.ts
@@ -1,5 +1,6 @@
 import {
   isArray,
+  isBigint,
   isBoolean,
   isDate,
   isNull,
@@ -13,6 +14,8 @@ import {
   isTypedArray,
   isURL,
 } from './is.js';
+import { walker } from './plainer.js';
+import SuperJSON from './index.js';
 
 import { test, expect } from 'vitest';
 
@@ -91,4 +94,33 @@ test('Date exception', () => {
 test('Regression: null-prototype object', () => {
   expect(isPlainObject(Object.create(null))).toBe(true);
   expect(isPrimitive(Object.create(null))).toBe(false);
+});
+
+test('isBigint', () => {
+  expect(isBigint(BigInt(0))).toBe(true);
+  expect(isBigint(0n)).toBe(true);
+  expect(isBigint(BigInt(9007199254740991))).toBe(true);
+  expect(isBigint(0)).toBe(false);
+  expect(isBigint('0')).toBe(false);
+  expect(isBigint(null)).toBe(false);
+  expect(isBigint(undefined)).toBe(false);
+});
+
+test('isPrimitive returns true for bigint values', () => {
+  expect(isPrimitive(BigInt(0))).toBe(true);
+  expect(isPrimitive(0n)).toBe(true);
+  expect(isPrimitive(BigInt(9007199254740991))).toBe(true);
+});
+
+test('walker does not enter identity tracking for bigint primitives', () => {
+  const identities = new Map();
+  const superJson = new SuperJSON();
+  const bigintValue = BigInt(42);
+
+  walker({ a: bigintValue, b: bigintValue }, identities, superJson, false);
+
+  // If bigint is treated as a primitive, it should not be added to identities.
+  // Since isPrimitive does not include bigint yet, this test should fail:
+  // bigint values will be tracked in identities when they shouldn't be.
+  expect(identities.has(bigintValue)).toBe(false);
 });


### PR DESCRIPTION
## Write failing tests for bigint in isPrimitive

**Category:** `test` | **Contributor:** test-agent

Closes #116

### Changes
Add test cases to src/is.test.ts that verify isPrimitive returns true for bigint values (e.g., BigInt(0), BigInt(9007199254740991), 0n). Also add a test verifying that the walker in plainer.ts correctly handles bigint as a primitive (does not enter identity tracking). These tests should FAIL initially because isPrimitive does not yet include bigint.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*