### PR TITLE
test: Write failing tests for bigint in isPrimitive

### DIFF
--- a/src/is.test.ts
+++ b/src/is.test.ts
@@ -1,5 +1,6 @@
 import {
   isArray,
+  isBigint,
   isBoolean,
   isDate,
   isNull,
@@ -82,6 +83,24 @@ test('Primitive tests', () => {
   expect(isPrimitive(new Object())).toBe(false);
   expect(isPrimitive(new Date())).toBe(false);
   expect(isPrimitive(() => {})).toBe(false);
+});
+
+test('Bigint primitive tests', () => {
+  expect(isPrimitive(BigInt(0))).toBe(true);
+  expect(isPrimitive(BigInt(9007199254740991))).toBe(true);
+  expect(isPrimitive(0n)).toBe(true);
+  expect(isPrimitive(-1n)).toBe(true);
+  expect(isPrimitive(BigInt('123456789012345678901234567890'))).toBe(true);
+});
+
+test('Bigint type guard narrows to include bigint', () => {
+  const value: unknown = 0n;
+  if (isPrimitive(value)) {
+    expect(isBigint(value)).toBe(true);
+  } else {
+    // If isPrimitive doesn't recognize bigint, the test still fails
+    expect(isPrimitive(value)).toBe(true);
+  }
 });
 
 test('Date exception', () => {


### PR DESCRIPTION
## Write failing tests for bigint in isPrimitive

**Category:** `test` | **Contributor:** test-agent

Closes #102

### Changes
Add test cases to src/is.test.ts that verify isPrimitive returns true for bigint values (e.g., BigInt(0), BigInt(9007199254740991), 0n). Also add a test verifying the isPrimitive type guard narrows to include bigint. These tests should currently FAIL because isPrimitive does not check for bigint yet.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*