### PR TITLE
test: Write failing tests for bigint in isPrimitive

### DIFF
--- a/src/is.test.ts
+++ b/src/is.test.ts
@@ -1,5 +1,6 @@
 import {
   isArray,
+  isBigint,
   isBoolean,
   isDate,
   isNull,
@@ -13,6 +14,8 @@ import {
   isTypedArray,
   isURL,
 } from './is.js';
+
+import SuperJSON from './index.js';
 
 import { test, expect } from 'vitest';
 
@@ -91,4 +94,34 @@ test('Date exception', () => {
 test('Regression: null-prototype object', () => {
   expect(isPlainObject(Object.create(null))).toBe(true);
   expect(isPrimitive(Object.create(null))).toBe(false);
+});
+
+test('isBigint returns true for bigint values', () => {
+  expect(isBigint(BigInt(0))).toBe(true);
+  expect(isBigint(BigInt(9007199254740991))).toBe(true);
+  expect(isBigint(42n)).toBe(true);
+  expect(isBigint(-1n)).toBe(true);
+  expect(isBigint(0n)).toBe(true);
+});
+
+test('isBigint returns false for non-bigint values', () => {
+  expect(isBigint(0)).toBe(false);
+  expect(isBigint('42')).toBe(false);
+  expect(isBigint(null)).toBe(false);
+  expect(isBigint(undefined)).toBe(false);
+});
+
+test('isPrimitive returns true for bigint values', () => {
+  expect(isPrimitive(BigInt(0))).toBe(true);
+  expect(isPrimitive(BigInt(9007199254740991))).toBe(true);
+  expect(isPrimitive(42n)).toBe(true);
+  expect(isPrimitive(-1n)).toBe(true);
+  expect(isPrimitive(0n)).toBe(true);
+  expect(isPrimitive(-9007199254740991n)).toBe(true);
+});
+
+test('Bigint round-trip through serialize/deserialize', () => {
+  const obj = { count: 42n, zero: 0n, large: BigInt(9007199254740991) };
+  const result = SuperJSON.deserialize(SuperJSON.serialize(obj));
+  expect(result).toEqual(obj);
 });


### PR DESCRIPTION
## Write failing tests for bigint in isPrimitive

**Category:** `test` | **Contributor:** test-agent

Closes #97

### Changes
Add tests to src/is.test.ts that verify: (1) isPrimitive returns true for bigint values (e.g., BigInt(0), BigInt(9007199254740991), 42n), (2) isBigint returns true for bigint values (confirm existing coverage). Also add a test verifying that the full serialize/deserialize round-trip in index.test.ts-style works for objects containing bigint primitives detected via isPrimitive. These tests should FAIL because isPrimitive currently does not check for bigint.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*