### PR TITLE
test: Write tests for BigInt64Array and BigUint64Array support

### DIFF
--- a/src/is.test.ts
+++ b/src/is.test.ts
@@ -92,3 +92,15 @@ test('Regression: null-prototype object', () => {
   expect(isPlainObject(Object.create(null))).toBe(true);
   expect(isPrimitive(Object.create(null))).toBe(false);
 });
+
+test('isTypedArray returns true for BigInt64Array', () => {
+  expect(isTypedArray(new BigInt64Array())).toBe(true);
+  expect(isTypedArray(BigInt64Array.of(1n, 2n, 3n))).toBe(true);
+  expect(isTypedArray(new BigInt64Array([0n]))).toBe(true);
+});
+
+test('isTypedArray returns true for BigUint64Array', () => {
+  expect(isTypedArray(new BigUint64Array())).toBe(true);
+  expect(isTypedArray(BigUint64Array.of(1n, 2n, 3n))).toBe(true);
+  expect(isTypedArray(new BigUint64Array([0n]))).toBe(true);
+});

--- a/src/transformer.test.ts
+++ b/src/transformer.test.ts
@@ -2,6 +2,34 @@ import SuperJSON from './index.js';
 
 import { test, expect } from 'vitest';
 
+test('BigInt64Array round-trips through serialize/deserialize', () => {
+  const input = { arr: BigInt64Array.of(1n, -2n, 3n) };
+  const output = SuperJSON.deserialize(SuperJSON.serialize(input));
+  expect(output.arr).toBeInstanceOf(BigInt64Array);
+  expect(output.arr).toEqual(BigInt64Array.of(1n, -2n, 3n));
+});
+
+test('BigUint64Array round-trips through serialize/deserialize', () => {
+  const input = { arr: BigUint64Array.of(1n, 2n, 3n) };
+  const output = SuperJSON.deserialize(SuperJSON.serialize(input));
+  expect(output.arr).toBeInstanceOf(BigUint64Array);
+  expect(output.arr).toEqual(BigUint64Array.of(1n, 2n, 3n));
+});
+
+test('empty BigInt64Array round-trips through serialize/deserialize', () => {
+  const input = { arr: new BigInt64Array() };
+  const output = SuperJSON.deserialize(SuperJSON.serialize(input));
+  expect(output.arr).toBeInstanceOf(BigInt64Array);
+  expect(output.arr.length).toBe(0);
+});
+
+test('empty BigUint64Array round-trips through serialize/deserialize', () => {
+  const input = { arr: new BigUint64Array() };
+  const output = SuperJSON.deserialize(SuperJSON.serialize(input));
+  expect(output.arr).toBeInstanceOf(BigUint64Array);
+  expect(output.arr.length).toBe(0);
+});
+
 test('throws an descriptive error when transforming', () => {
   const instance = new SuperJSON();
   class FunnyNumber {


### PR DESCRIPTION
## Write tests for BigInt64Array and BigUint64Array support

**Category:** `test` | **Contributor:** test-agent

Closes #94

### Changes
Add tests to is.test.ts verifying that isTypedArray() returns true for BigInt64Array and BigUint64Array instances. Add tests to transformer.test.ts verifying that BigInt64Array and BigUint64Array can round-trip through SuperJSON serialize/deserialize (i.e., serializing a BigInt64Array and deserializing it yields an equivalent BigInt64Array, same for BigUint64Array). The tests should currently fail because the TypedArrayConstructor union and constructorToName map don't include these types yet.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*