### PR TITLE
test: Write failing tests for isPrimitive bigint support

### DIFF
--- a/src/is.test.ts
+++ b/src/is.test.ts
@@ -74,6 +74,11 @@ test('Primitive tests', () => {
   expect(isPrimitive(null)).toBe(true);
   expect(isPrimitive(undefined)).toBe(true);
 
+  expect(isPrimitive(0n)).toBe(true);
+  expect(isPrimitive(BigInt(42))).toBe(true);
+  expect(isPrimitive(BigInt('999999999999999999'))).toBe(true);
+  expect(isPrimitive(-1n)).toBe(true);
+
   expect(isPrimitive(NaN)).toBe(false);
   expect(isPrimitive([])).toBe(false);
   expect(isPrimitive([])).toBe(false);
@@ -82,6 +87,9 @@ test('Primitive tests', () => {
   expect(isPrimitive(new Object())).toBe(false);
   expect(isPrimitive(new Date())).toBe(false);
   expect(isPrimitive(() => {})).toBe(false);
+  expect(isPrimitive(new Map())).toBe(false);
+  expect(isPrimitive(new Set())).toBe(false);
+  expect(isPrimitive(/regex/)).toBe(false);
 });
 
 test('Date exception', () => {


### PR DESCRIPTION
## Write failing tests for isPrimitive bigint support

**Category:** `test` | **Contributor:** test-agent

Closes #86

### Changes
Add test cases to src/is.test.ts that verify isPrimitive returns true for bigint values. Add cases like isPrimitive(0n), isPrimitive(BigInt(42)), and isPrimitive(BigInt('999999999999999999')). These tests should currently FAIL because isPrimitive does not check for bigint. Also add a negative test ensuring isPrimitive still returns false for objects, arrays, etc.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*