### PR TITLE
test: Write failing tests for BigInt typed array serialization

### DIFF
--- a/src/transformer.test.ts
+++ b/src/transformer.test.ts
@@ -1,6 +1,52 @@
 import SuperJSON from './index.js';
 
-import { test, expect } from 'vitest';
+import { test, expect, describe } from 'vitest';
+
+describe('BigInt typed array serialization', () => {
+  test('BigInt64Array round-trips correctly', () => {
+    const input = new BigInt64Array([0n, 1n, -1n, 9007199254740993n]);
+    const output = SuperJSON.deserialize(SuperJSON.serialize(input));
+    expect(output).toBeInstanceOf(BigInt64Array);
+    expect(output).toEqual(input);
+  });
+
+  test('BigUint64Array round-trips correctly', () => {
+    const input = new BigUint64Array([0n, 1n, 18446744073709551615n]);
+    const output = SuperJSON.deserialize(SuperJSON.serialize(input));
+    expect(output).toBeInstanceOf(BigUint64Array);
+    expect(output).toEqual(input);
+  });
+
+  test('BigInt typed arrays nested inside objects round-trip', () => {
+    const input = {
+      signed: new BigInt64Array([42n, -42n]),
+      unsigned: new BigUint64Array([100n]),
+      label: 'test',
+    };
+    const output = SuperJSON.deserialize<typeof input>(
+      SuperJSON.serialize(input)
+    );
+    expect(output.signed).toBeInstanceOf(BigInt64Array);
+    expect(output.signed).toEqual(input.signed);
+    expect(output.unsigned).toBeInstanceOf(BigUint64Array);
+    expect(output.unsigned).toEqual(input.unsigned);
+    expect(output.label).toBe('test');
+  });
+
+  test('empty BigInt64Array round-trips', () => {
+    const input = new BigInt64Array([]);
+    const output = SuperJSON.deserialize(SuperJSON.serialize(input));
+    expect(output).toBeInstanceOf(BigInt64Array);
+    expect(output).toEqual(input);
+  });
+
+  test('empty BigUint64Array round-trips', () => {
+    const input = new BigUint64Array([]);
+    const output = SuperJSON.deserialize(SuperJSON.serialize(input));
+    expect(output).toBeInstanceOf(BigUint64Array);
+    expect(output).toEqual(input);
+  });
+});
 
 test('throws an descriptive error when transforming', () => {
   const instance = new SuperJSON();


### PR DESCRIPTION
## Write failing tests for BigInt typed array serialization

**Category:** `test` | **Contributor:** test-agent

Closes #82

### Changes
Add tests to src/transformer.test.ts that verify BigInt64Array and BigUint64Array can round-trip through SuperJSON serialize/deserialize. Tests should cover: (1) a BigInt64Array with sample values round-trips correctly, (2) a BigUint64Array with sample values round-trips correctly, (3) BigInt typed arrays nested inside objects round-trip, (4) empty BigInt typed arrays round-trip. Use the same pattern as existing typed array tests in the codebase. These tests MUST fail initially since the implementation does not exist yet.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*