### PR TITLE
test: Write failing tests for regex with forward slashes

### DIFF
--- a/src/transformer.test.ts
+++ b/src/transformer.test.ts
@@ -26,3 +26,35 @@ test('throws an descriptive error when transforming', () => {
     `Trying to deserialize unknown class 'NotRegistered' - check https://github.com/blitz-js/superjson/issues/116#issuecomment-773996564`
   );
 });
+
+test('RegExp round-trip: simple pattern without slashes', () => {
+  const regex = /simple/g;
+  const result = SuperJSON.deserialize<RegExp>(SuperJSON.serialize(regex));
+  expect(result).toBeInstanceOf(RegExp);
+  expect(result.source).toBe('simple');
+  expect(result.flags).toBe('g');
+});
+
+test('RegExp round-trip: escaped slash in pattern', () => {
+  const regex = /a\/b/g;
+  const result = SuperJSON.deserialize<RegExp>(SuperJSON.serialize(regex));
+  expect(result).toBeInstanceOf(RegExp);
+  expect(result.source).toBe('a\\/b');
+  expect(result.flags).toBe('g');
+});
+
+test('RegExp round-trip: URL-like pattern with slashes', () => {
+  const regex = /https:\/\/example\.com/i;
+  const result = SuperJSON.deserialize<RegExp>(SuperJSON.serialize(regex));
+  expect(result).toBeInstanceOf(RegExp);
+  expect(result.source).toBe('https:\\/\\/example\\.com');
+  expect(result.flags).toBe('i');
+});
+
+test('RegExp round-trip: pattern that is just slashes', () => {
+  const regex = /\/\//g;
+  const result = SuperJSON.deserialize<RegExp>(SuperJSON.serialize(regex));
+  expect(result).toBeInstanceOf(RegExp);
+  expect(result.source).toBe('\\/\\/');
+  expect(result.flags).toBe('g');
+});


### PR DESCRIPTION
## Write failing tests for regex with forward slashes

**Category:** `test` | **Contributor:** test-agent

Closes #453

### Changes
Add tests to src/transformer.test.ts that verify correct round-trip serialization/deserialization of RegExp values containing forward slashes. Test cases should include: (1) /a\/b/g — escaped slash in pattern with flags, (2) /https:\/\/example\.com/i — URL-like pattern, (3) /\/\//g — pattern that is just slashes, (4) /simple/g — baseline without slashes (should already pass). Use SuperJSON.serialize() and SuperJSON.deserialize() to test the full round-trip. Each test should assert that the deserialized value is a RegExp with the correct source and flags. The new tests for patterns containing slashes are expected to FAIL against the current implementation.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*