### PR TITLE
test: Write failing tests for getNthKey negative index validation

### DIFF
--- a/src/accessDeep.test.ts
+++ b/src/accessDeep.test.ts
@@ -1,4 +1,4 @@
-import { setDeep } from './accessDeep.js';
+import { getDeep, setDeep } from './accessDeep.js';
 
 import { describe, it, expect } from 'vitest';
 
@@ -27,5 +27,22 @@ describe('setDeep', () => {
     expect(obj).toEqual({
       a: new Set([10, new Set([NaN])]),
     });
+  });
+});
+
+describe('getNthKey negative index validation', () => {
+  it('getDeep on a Set with a negative index throws', () => {
+    const obj = { a: new Set([10, 20, 30]) };
+    expect(() => getDeep(obj, ['a', -1])).toThrow('index out of bounds');
+  });
+
+  it('getDeep on a Map with a negative row index throws', () => {
+    const obj = { a: new Map([['x', 1], ['y', 2]]) };
+    expect(() => getDeep(obj, ['a', -1, 1])).toThrow('index out of bounds');
+  });
+
+  it('setDeep on a Set with a negative index throws', () => {
+    const obj = { a: new Set([10, 20, 30]) };
+    expect(() => setDeep(obj, ['a', -1], v => v)).toThrow('index out of bounds');
   });
 });


### PR DESCRIPTION
## Write failing tests for getNthKey negative index validation

**Category:** `test` | **Contributor:** test-agent

Closes #450

### Changes
Add tests to src/accessDeep.test.ts that verify getNthKey throws an 'index out of bounds' error when called with a negative index. Since getNthKey is not exported directly, test through the public getDeep/setDeep API using Sets and Maps with negative path indices. Add a describe block for 'getNthKey negative index validation' with cases: (1) getDeep on a Set with a negative index throws, (2) getDeep on a Map with a negative row index throws, (3) setDeep on a Set with a negative index throws. These tests should currently FAIL because the negative check doesn't exist yet.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*