### PR TITLE
test: Write failing tests for descriptive deserialization errors

### DIFF
--- a/src/transformer.test.ts
+++ b/src/transformer.test.ts
@@ -26,3 +26,39 @@ test('throws an descriptive error when transforming', () => {
     `Trying to deserialize unknown class 'NotRegistered' - check https://github.com/blitz-js/superjson/issues/116#issuecomment-773996564`
   );
 });
+
+test('throws a descriptive error when deserializing an unknown symbol', () => {
+  const instance = new SuperJSON();
+  expect(() =>
+    instance.deserialize({
+      json: { value: 'test' },
+      meta: {
+        values: [['symbol', 'nonExistentSymbol']],
+      },
+    })
+  ).toThrowError(/nonExistentSymbol/);
+});
+
+test('throws a descriptive error when deserializing an unknown typed array', () => {
+  const instance = new SuperJSON();
+  expect(() =>
+    instance.deserialize({
+      json: { value: [1, 2, 3] },
+      meta: {
+        values: [['typed-array', 'FakeTypedArray']],
+      },
+    })
+  ).toThrowError(/FakeTypedArray/);
+});
+
+test('throws a descriptive error when deserializing an unknown custom transformer', () => {
+  const instance = new SuperJSON();
+  expect(() =>
+    instance.deserialize({
+      json: { value: 'test' },
+      meta: {
+        values: [['custom', 'nonExistentTransformer']],
+      },
+    })
+  ).toThrowError(/nonExistentTransformer/);
+});


### PR DESCRIPTION
## Write failing tests for descriptive deserialization errors

**Category:** `test` | **Contributor:** test-agent

Closes #457

### Changes
Add three test cases to src/transformer.test.ts that verify deserialization error messages include the problematic identifier:

1. **Unknown symbol**: Attempt to deserialize with meta `['symbol', 'nonExistentSymbol']`. Assert the error message contains the string 'nonExistentSymbol'.
2. **Unknown typed array**: Attempt to deserialize with meta `['typed-array', 'FakeTypedArray']`. Assert the error message contains the string 'FakeTypedArray'.
3. **Unknown custom transformer**: Attempt to deserialize with meta `['custom', 'nonExistentTransformer']`. Assert the error message contains the string 'nonExistentTransformer'.

Follow the existing test pattern in the file (the class deserialization error test). Each test should call `instance.deserialize()` with crafted meta annotations and use `toThrowError` with a regex or substring that includes the identifier value.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*