### PR TITLE
test: Write tests for BigInt polyfill fallback throwing on missing BigInt

### DIFF
--- a/src/transformer.test.ts
+++ b/src/transformer.test.ts
@@ -1,6 +1,6 @@
 import SuperJSON from './index.js';
 
-import { test, expect } from 'vitest';
+import { test, expect, describe, vi, afterEach } from 'vitest';
 
 test('throws an descriptive error when transforming', () => {
   const instance = new SuperJSON();
@@ -25,4 +25,83 @@ test('throws an descriptive error when transforming', () => {
   ).toThrowError(
     `Trying to deserialize unknown class 'NotRegistered' - check https://github.com/blitz-js/superjson/issues/116#issuecomment-773996564`
   );
+});
+
+describe('BigInt deserialization', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  test('throws an error when BigInt is not available', () => {
+    vi.stubGlobal('BigInt', undefined);
+
+    const payload = {
+      json: '12345',
+      meta: {
+        values: ['bigint'],
+      },
+    };
+
+    expect(() => SuperJSON.deserialize(payload)).toThrow();
+  });
+
+  test('throws an error with a descriptive message when BigInt is unavailable', () => {
+    vi.stubGlobal('BigInt', undefined);
+
+    const payload = {
+      json: '999',
+      meta: {
+        values: ['bigint'],
+      },
+    };
+
+    expect(() => SuperJSON.deserialize(payload)).toThrow(/BigInt/);
+  });
+
+  test('throws when BigInt is undefined and bigint value is zero', () => {
+    vi.stubGlobal('BigInt', undefined);
+
+    const payload = {
+      json: '0',
+      meta: {
+        values: ['bigint'],
+      },
+    };
+
+    expect(() => SuperJSON.deserialize(payload)).toThrow();
+  });
+
+  test('successfully deserializes bigint when BigInt is available', () => {
+    const original = BigInt('12345');
+    const serialized = SuperJSON.serialize(original);
+    const deserialized = SuperJSON.deserialize<bigint>(serialized);
+
+    expect(deserialized).toBe(original);
+    expect(typeof deserialized).toBe('bigint');
+  });
+
+  test('successfully deserializes a large bigint value', () => {
+    const original = BigInt('9007199254740993');
+    const serialized = SuperJSON.serialize(original);
+    const deserialized = SuperJSON.deserialize<bigint>(serialized);
+
+    expect(deserialized).toBe(original);
+  });
+
+  test('successfully deserializes bigint zero', () => {
+    const original = BigInt(0);
+    const serialized = SuperJSON.serialize(original);
+    const deserialized = SuperJSON.deserialize<bigint>(serialized);
+
+    expect(deserialized).toBe(original);
+    expect(typeof deserialized).toBe('bigint');
+  });
+
+  test('successfully deserializes negative bigint', () => {
+    const original = BigInt('-42');
+    const serialized = SuperJSON.serialize(original);
+    const deserialized = SuperJSON.deserialize<bigint>(serialized);
+
+    expect(deserialized).toBe(original);
+  });
 });


### PR DESCRIPTION
## Write tests for BigInt polyfill fallback throwing on missing BigInt

**Category:** `test` | **Contributor:** test-agent

Closes #455

### Changes
Add tests to src/transformer.test.ts that verify the BigInt deserializer behavior when BigInt is unavailable. Tests should: (1) mock globalThis.BigInt as undefined, (2) call the bigint untransform path (e.g. via SuperJSON.deserialize with a bigint-annotated payload), (3) assert that it throws an error (not returns a string). Also add a positive test that confirms when BigInt IS available, deserialization works correctly and returns a bigint. The new tests should append to the existing test file without modifying existing tests.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*