### PR TITLE
test: Write failing tests for parse() malformed JSON handling

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1345,6 +1345,65 @@ test('deserialize in place', () => {
   expect(deserializedCopy).toEqual(deserializedInPlace);
 });
 
+describe('parse() malformed JSON handling', () => {
+  it('throws a descriptive error for invalid JSON object syntax', () => {
+    expect(() => SuperJSON.parse('{invalid}')).toThrow(/superjson|Malformed JSON/i);
+  });
+
+  it('throws a descriptive error for non-JSON strings', () => {
+    expect(() => SuperJSON.parse('not json')).toThrow(/superjson|Malformed JSON/i);
+  });
+
+  it('throws a descriptive error for empty string input', () => {
+    expect(() => SuperJSON.parse('')).toThrow(/superjson|Malformed JSON/i);
+  });
+
+  it('throws a descriptive error for JSON with undefined value', () => {
+    expect(() => SuperJSON.parse('{"a": undefined}')).toThrow(/superjson|Malformed JSON/i);
+  });
+
+  it('preserves the original SyntaxError details in the error message', () => {
+    try {
+      SuperJSON.parse('{invalid}');
+      expect.unreachable('Should have thrown');
+    } catch (e: unknown) {
+      const error = e as Error;
+      // The wrapped error should contain the original SyntaxError message for debuggability
+      expect(error.message).toMatch(/unexpected|token|parse/i);
+    }
+  });
+
+  it('preserves original error details for non-JSON input', () => {
+    try {
+      SuperJSON.parse('not json');
+      expect.unreachable('Should have thrown');
+    } catch (e: unknown) {
+      const error = e as Error;
+      expect(error.message).toMatch(/unexpected|token|parse/i);
+    }
+  });
+
+  it('still parses valid JSON correctly through parse()', () => {
+    const input = { a: 1, b: 'hello', c: [1, 2, 3] };
+    const stringified = SuperJSON.stringify(input);
+    const parsed = SuperJSON.parse<typeof input>(stringified);
+    expect(parsed).toEqual(input);
+  });
+
+  it('still parses valid JSON with SuperJSON metadata correctly', () => {
+    const date = new Date('2024-01-01T00:00:00.000Z');
+    const stringified = SuperJSON.stringify({ date });
+    const parsed = SuperJSON.parse<{ date: Date }>(stringified);
+    expect(parsed.date).toBeInstanceOf(Date);
+    expect(parsed.date.toISOString()).toBe('2024-01-01T00:00:00.000Z');
+  });
+
+  it('works with instance method parse() for malformed JSON', () => {
+    const instance = new SuperJSON();
+    expect(() => instance.parse('{invalid}')).toThrow(/superjson|Malformed JSON/i);
+  });
+});
+
 test('#310 fixes backwards compat', () => {
   expect(
     SuperJSON.deserialize({


### PR DESCRIPTION
## Write failing tests for parse() malformed JSON handling

**Category:** `test` | **Contributor:** test-agent

Closes #472

### Changes
Add a new describe block in src/index.test.ts for malformed JSON handling in parse(). Write tests that: (1) call SuperJSON.parse() with invalid JSON strings (e.g. '{invalid}', 'not json', '', '{"a": undefined}') and expect a descriptive error to be thrown that includes 'superjson' or contextual information rather than a raw SyntaxError, (2) verify the error message contains the original error details for debuggability, (3) confirm that valid JSON still parses correctly through parse(). These tests should FAIL against the current implementation because parse() currently throws raw SyntaxError with no superjson context.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*