### PR TITLE
test: Write tests for RegExp deserialization validation

### DIFF
--- a/src/transformer.test.ts
+++ b/src/transformer.test.ts
@@ -26,3 +26,70 @@ test('throws an descriptive error when transforming', () => {
     `Trying to deserialize unknown class 'NotRegistered' - check https://github.com/blitz-js/superjson/issues/116#issuecomment-773996564`
   );
 });
+
+test('RegExp deserialization throws on string missing leading slash', () => {
+  const instance = new SuperJSON();
+  expect(() =>
+    instance.deserialize({
+      json: 'noleadingslash/',
+      meta: {
+        values: 'regexp',
+      },
+    })
+  ).toThrowError(/noleadingslash/);
+});
+
+test('RegExp deserialization throws on string with no closing slash', () => {
+  const instance = new SuperJSON();
+  expect(() =>
+    instance.deserialize({
+      json: '/unclosed',
+      meta: {
+        values: 'regexp',
+      },
+    })
+  ).toThrowError(/unclosed/);
+});
+
+test('RegExp deserialization throws on empty string', () => {
+  const instance = new SuperJSON();
+  expect(() =>
+    instance.deserialize({
+      json: '',
+      meta: {
+        values: 'regexp',
+      },
+    })
+  ).toThrowError(/regexp/i);
+});
+
+test('RegExp deserialization throws on invalid flags', () => {
+  const instance = new SuperJSON();
+  expect(() =>
+    instance.deserialize({
+      json: '/pattern/xyz',
+      meta: {
+        values: 'regexp',
+      },
+    })
+  ).toThrowError(/invalid|flag|xyz/i);
+});
+
+test('RegExp round-trips correctly with flags', () => {
+  const instance = new SuperJSON();
+  const regex = /foo/gi;
+  const serialized = instance.serialize(regex);
+  const deserialized = instance.deserialize(serialized);
+  expect(deserialized).toBeInstanceOf(RegExp);
+  expect((deserialized as RegExp).source).toBe('foo');
+  expect((deserialized as RegExp).flags).toBe('gi');
+});
+
+test('RegExp round-trips correctly with escaped slash', () => {
+  const instance = new SuperJSON();
+  const regex = /escaped\/slash/;
+  const serialized = instance.serialize(regex);
+  const deserialized = instance.deserialize(serialized);
+  expect(deserialized).toBeInstanceOf(RegExp);
+  expect((deserialized as RegExp).source).toBe('escaped\\/slash');
+});


### PR DESCRIPTION
## Write tests for RegExp deserialization validation

**Category:** `test` | **Contributor:** test-agent

Closes #510

### Changes
Add tests to transformer.test.ts that verify RegExp deserialization behavior with malformed/corrupted input. Tests should cover: (1) a string missing the leading `/` entirely, (2) a string with no closing `/` (e.g. `/unclosed`), (3) an empty string, (4) a string with invalid flags like `/pattern/xyz`. Each test should assert that a descriptive error is thrown (not a raw SyntaxError). Also add a test confirming valid RegExp patterns like `/foo/gi` and `/escaped\/slash/` still round-trip correctly.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*