### PR TITLE
test: Write failing tests for getNthKey off-by-one bug

### DIFF
--- a/src/accessDeep.test.ts
+++ b/src/accessDeep.test.ts
@@ -1,4 +1,4 @@
-import { setDeep } from './accessDeep.js';
+import { setDeep, getDeep } from './accessDeep.js';
 
 import { describe, it, expect } from 'vitest';
 
@@ -27,5 +27,31 @@ describe('setDeep', () => {
     expect(obj).toEqual({
       a: new Set([10, new Set([NaN])]),
     });
+  });
+});
+
+describe('getNthKey boundary checks', () => {
+  it('should throw when accessing a Set element at index === set.size', () => {
+    const set = new Set([1, 2, 3]);
+    expect(() => getDeep(set, ['3'])).toThrow('index out of bounds');
+  });
+
+  it('should throw when accessing a Map key at row === map.size', () => {
+    const map = new Map([
+      ['a', 1],
+      ['b', 2],
+    ]);
+    expect(() => getDeep(map, ['2', '0'])).toThrow('index out of bounds');
+  });
+
+  it('should return the correct value when accessing at the last valid index', () => {
+    const set = new Set([1, 2, 3]);
+    expect(getDeep(set, ['2'])).toBe(3);
+
+    const map = new Map([
+      ['a', 1],
+      ['b', 2],
+    ]);
+    expect(getDeep(map, ['1', '0'])).toBe('b');
   });
 });


### PR DESCRIPTION
## Write failing tests for getNthKey off-by-one bug

**Category:** `test` | **Contributor:** test-agent

Closes #533

### Changes
Add tests to `src/accessDeep.test.ts` that expose the off-by-one bug in `getNthKey`. Import `getDeep` if not already imported. Add a describe block for `getNthKey boundary checks` with tests:
1. Accessing a Set element at index === set.size should throw 'index out of bounds' (e.g., `new Set([1,2,3])` with index 3).
2. Accessing a Map key at row === map.size should throw 'index out of bounds'.
3. Confirm that accessing at index `size - 1` (the last valid index) does NOT throw and returns the correct value.
These tests exercise `getNthKey` indirectly through `getDeep` since `getNthKey` is not exported. Use `getDeep(set, ['3'])` for a 3-element Set, and `getDeep(map, ['2', '0'])` for a 2-element Map to hit the boundary.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*