### PR TITLE
test: Add edge-case tests for parsePath escape handling

### DIFF
--- a/src/pathstringifier.test.ts
+++ b/src/pathstringifier.test.ts
@@ -9,6 +9,9 @@ describe('parsePath', () => {
     ['test\\\\.a.b', ['test\\.a', 'b']],
     ['test\\a.b', ['test\\a', 'b']],
     ['test\\\\a.b', ['test\\\\a', 'b']],
+    ['foo\\', ['foo\\']],
+    ['a..b', ['a', '', 'b']],
+    ['\\.', ['.']],
   ])('legacy parsePath(%p) === %p', (input, expectedOutput) => {
     expect(parsePath(input, true)).toEqual(expectedOutput);
   });
@@ -18,6 +21,10 @@ describe('parsePath', () => {
     ['test\\.a.b', ['test.a', 'b']],
     ['test\\\\.a.b', ['test\\', 'a', 'b']],
     ['test\\\\a.b', ['test\\a', 'b']],
+    ['a\\.\\..b', ['a..', 'b']],
+    ['a\\\\\\.b', ['a\\.b']],
+    ['a..b', ['a', '', 'b']],
+    ['\\.', ['.']],
   ])('parsePath(%p) === %p', (input, expectedOutput) => {
     expect(parsePath(input, false)).toEqual(expectedOutput);
   });


### PR DESCRIPTION
## Add edge-case tests for parsePath escape handling

**Category:** `test` | **Contributor:** test-agent

Closes #523

### Changes
Add targeted edge-case tests to the existing parsePath test suite that exercise the escape-handling paths more thoroughly. These tests must pass against the CURRENT implementation (this is a refactor, not a new feature — existing behavior is correct). Add cases for: (1) non-legacy consecutive escaped dots like 'a\.\..b' → ['a..', 'b'], (2) non-legacy mixed escapes like 'a\\\.b' → ['a\.b'] (escaped backslash followed by escaped dot), (3) legacy path with trailing backslash 'foo\' to document legacy tolerance, (4) empty segments like 'a..b' → ['a','','b'] for both legacy and non-legacy, (5) single escaped dot as entire path '\.'' → ['.'] for both modes. These tests pin down behavior so the refactor in the next task can be validated.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*