### PR TITLE
bug_fix: Fix 'transfomers' and 'CustomTransfomer' typos

### DIFF
--- a/src/custom-transformer-registry.ts
+++ b/src/custom-transformer-registry.ts
@@ -1,7 +1,7 @@
 import { JSONValue } from './types.js';
 import { find } from './util.js';
 
-export interface CustomTransfomer<I, O extends JSONValue> {
+export interface CustomTransformer<I, O extends JSONValue> {
   name: string;
   isApplicable: (v: any) => v is I;
   serialize: (v: I) => O;
@@ -9,19 +9,19 @@ export interface CustomTransfomer<I, O extends JSONValue> {
 }
 
 export class CustomTransformerRegistry {
-  private transfomers: Record<string, CustomTransfomer<any, any>> = {};
+  private transformers: Record<string, CustomTransformer<any, any>> = {};
 
-  register<I, O extends JSONValue>(transformer: CustomTransfomer<I, O>) {
-    this.transfomers[transformer.name] = transformer;
+  register<I, O extends JSONValue>(transformer: CustomTransformer<I, O>) {
+    this.transformers[transformer.name] = transformer;
   }
 
   findApplicable<T>(v: T) {
-    return find(this.transfomers, transformer =>
+    return find(this.transformers, transformer =>
       transformer.isApplicable(v)
-    ) as CustomTransfomer<T, JSONValue> | undefined;
+    ) as CustomTransformer<T, JSONValue> | undefined;
   }
 
   findByName(name: string) {
-    return this.transfomers[name];
+    return this.transformers[name];
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ import { Class, JSONValue, SuperJSONResult, SuperJSONValue } from './types.js';
 import { ClassRegistry, RegisterOptions } from './class-registry.js';
 import { Registry } from './registry.js';
 import {
-  CustomTransfomer,
+  CustomTransformer,
   CustomTransformerRegistry,
 } from './custom-transformer-registry.js';
 import {
@@ -100,7 +100,7 @@ export default class SuperJSON {
 
   readonly customTransformerRegistry = new CustomTransformerRegistry();
   registerCustom<I, O extends JSONValue>(
-    transformer: Omit<CustomTransfomer<I, O>, 'name'>,
+    transformer: Omit<CustomTransformer<I, O>, 'name'>,
     name: string
   ) {
     this.customTransformerRegistry.register({


### PR DESCRIPTION
## Fix 'transfomers' and 'CustomTransfomer' typos

**Category:** `bug_fix` | **Contributor:** test-agent

Closes #553

### Changes
Rename the interface `CustomTransfomer` to `CustomTransformer` (add missing 'r') and rename the private field `transfomers` to `transformers` in src/custom-transformer-registry.ts. Update all references in src/index.ts (and any other files that import `CustomTransfomer`). This is a pure rename — no behavioral change.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*