### PR TITLE
test: Write failing tests for getNthKey boundary check

### DIFF
--- a/src/accessDeep.test.ts
+++ b/src/accessDeep.test.ts
@@ -1,4 +1,4 @@
-import { setDeep } from './accessDeep.js';
+import { setDeep, getDeep } from './accessDeep.js';
 
 import { describe, it, expect } from 'vitest';
 
@@ -27,5 +27,29 @@ describe('setDeep', () => {
     expect(obj).toEqual({
       a: new Set([10, new Set([NaN])]),
     });
+  });
+});
+
+describe('getNthKey boundary checks', () => {
+  it('throws when accessing index equal to Set size', () => {
+    const obj = { a: new Set([10, 20, 30]) };
+    expect(() => getDeep(obj, ['a', 3])).toThrow('index out of bounds');
+  });
+
+  it('throws when accessing index equal to Map size', () => {
+    const obj = { a: new Map([['x', 1], ['y', 2]]) };
+    expect(() => getDeep(obj, ['a', 2, 0])).toThrow('index out of bounds');
+  });
+
+  it('returns the last valid element of a Set (size - 1)', () => {
+    const obj = { a: new Set([10, 20, 30]) };
+    const result = getDeep(obj, ['a', 2]);
+    expect(result).toBe(30);
+  });
+
+  it('returns the last valid key of a Map (size - 1)', () => {
+    const obj = { a: new Map([['x', 1], ['y', 2]]) };
+    const result = getDeep(obj, ['a', 1, 0]);
+    expect(result).toBe('y');
   });
 });


### PR DESCRIPTION
## Write failing tests for getNthKey boundary check

**Category:** `test` | **Contributor:** test-agent

Closes #547

### Changes
Add tests to src/accessDeep.test.ts that expose the off-by-one error in getNthKey. Specifically: (1) Test that accessing index equal to size on a Set throws 'index out of bounds'. For example, `new Set([10, 20, 30])` has size 3, so accessing index 3 via getDeep should throw. (2) Test that accessing index equal to size on a Map throws similarly. (3) Test that accessing the last valid index (size - 1) still works correctly. Import `getDeep` from './accessDeep.js' and add a new describe block for 'getNthKey boundary checks'. The boundary tests for n === size should currently FAIL because the bug allows n === size through.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*